### PR TITLE
Changes for pad/caps methods renamed from 0.10 to 1.0

### DIFF
--- a/src/org/freedesktop/gstreamer/Pad.java
+++ b/src/org/freedesktop/gstreamer/Pad.java
@@ -119,7 +119,7 @@ public class Pad extends GstObject {
      * @return a newly allocated copy of the {@link Caps} of this pad.
      */
     public Caps getCaps() {
-        return gst.gst_pad_get_caps(this);
+        return gst.gst_pad_query_caps(this, null);
     }
     
     /**
@@ -166,7 +166,7 @@ public class Pad extends GstObject {
      * 
      */
     public Caps getNegotiatedCaps() {
-        return gst.gst_pad_get_negotiated_caps(this);
+        return gst.gst_pad_get_current_caps(this);
     }
     
     /**
@@ -194,7 +194,7 @@ public class Pad extends GstObject {
      * @return true if the pad can accept the caps.
      */
     public boolean acceptCaps(Caps caps) {
-        return gst.gst_pad_accept_caps(this, caps);
+        return gst.gst_pad_query_accept_caps(this, caps);
     }
     
     /**

--- a/src/org/freedesktop/gstreamer/lowlevel/GstPadAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GstPadAPI.java
@@ -101,16 +101,16 @@ public interface GstPadAPI extends com.sun.jna.Library {
     PadTemplate gst_pad_get_pad_template(Pad pad);
     
     /* capsnego function for connected/unconnected pads */
-    @CallerOwnsReturn Caps gst_pad_get_caps(Pad  pad);
+    @CallerOwnsReturn Caps gst_pad_query_caps(Pad pad, Caps caps);
     void gst_pad_fixate_caps(Pad pad, Caps caps);
-    boolean gst_pad_accept_caps(Pad pad, Caps caps);
+    boolean gst_pad_query_accept_caps(Pad pad, Caps caps);
     boolean gst_pad_set_caps(Pad pad, Caps caps);
     @CallerOwnsReturn Caps gst_pad_peer_get_caps(Pad pad);
     boolean gst_pad_peer_accept_caps(Pad pad, Caps caps);
     
     /* capsnego for connected pads */
     @CallerOwnsReturn Caps gst_pad_get_allowed_caps(Pad pad);
-    @CallerOwnsReturn Caps gst_pad_get_negotiated_caps(Pad pad);
+    @CallerOwnsReturn Caps gst_pad_get_current_caps(Pad pad);
 
     /* data passing functions to peer */
     FlowReturn gst_pad_push(Pad pad, @IncRef Buffer buffer);


### PR DESCRIPTION
As per migration guide:

https://cgit.freedesktop.org/cgit/?url=gstreamer/gstreamer/plain/docs/random/porting-to-1.0.txt
