### PR TITLE
Fix for MiniObject

### DIFF
--- a/src/org/freedesktop/gstreamer/ElementFactory.java
+++ b/src/org/freedesktop/gstreamer/ElementFactory.java
@@ -224,9 +224,11 @@ public class ElementFactory extends PluginFeature {
     
     @SuppressWarnings("unchecked")
     private static Element elementFor(Pointer ptr, String factoryName) {
-        Class<? extends Element> cls = typeMap.get(factoryName);
-        cls = (cls == null) ? (Class<Element>)GstTypes.classFor(ptr) : cls;
-        cls = (cls == null || !Element.class.isAssignableFrom(cls)) ? Element.class : cls;
+        Class<? extends Element> cls = ElementFactory.typeMap.get(factoryName);
+        if (cls == null) {
+            cls = (Class<Element>)GstTypes.classFor(Element.getType(ptr));
+            ElementFactory.typeMap.put(factoryName, cls);
+        }
         return NativeObject.objectFor(ptr, cls);
     }
 

--- a/src/org/freedesktop/gstreamer/GObject.java
+++ b/src/org/freedesktop/gstreamer/GObject.java
@@ -136,14 +136,23 @@ public abstract class GObject extends RefCountedObject {
      * Gives the type value.
      */
     public GType getType() {
-    	return new GType(new GObjectStruct(this).g_type_instance.g_class.getNativeLong(0).longValue());
+    	return GObject.getType(this.handle());
     }
+
+    public static GType getType(Pointer ptr) {
+    	// Quick getter for GType without allocation
+    	// same as : new GObjectStruct(ptr).g_type_instance.g_class.g_type 
+    	Pointer g_class = ptr.getPointer(0);
+    	return GType.valueOf(g_class.getNativeLong(0).longValue());
+    }
+
     /**
      * Gives the type name.
      */
     public String getTypeName() {
-    	return GOBJECT_API.g_type_name(getType());
+    	return this.getType().getTypeName();
     }
+    
     /**
      * Sets the value of a <tt>GObject</tt> property.
      *

--- a/src/org/freedesktop/gstreamer/Message.java
+++ b/src/org/freedesktop/gstreamer/Message.java
@@ -94,22 +94,4 @@ public class Message extends MiniObject {
 		return type;
     }
     
-    /**
-     * Gets a writable version of this Message.
-     * 
-     * @return a new Message (possibly a duplicate) that is writable.
-     */
-    public Message makeWritable() {
-        return makeWritable(getClass());
-    }
-    
-    /**
-     * Creates a copy of the message.
-     * 
-     * @return a copy of this message.
-     */
-    public Message copy() {
-        return (Message)gst.gst_mini_object_copy(this);
-    }
-    
 }

--- a/src/org/freedesktop/gstreamer/MiniObject.java
+++ b/src/org/freedesktop/gstreamer/MiniObject.java
@@ -1,17 +1,18 @@
-/* 
+/*
+ * Copyright (c) 2016 Christophe Lafolet
  * Copyright (c) 2014 Tom Greenwood <tgreenwood@cafex.com>
  * Copyright (c) 2009 Levente Farkas
  * Copyright (c) 2007 Wayne Meissner
- * 
+ *
  * This file is part of gstreamer-java.
  *
- * This code is free software: you can redistribute it and/or modify it under 
+ * This code is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 3 only, as
  * published by the Free Software Foundation.
  *
- * This code is distributed in the hope that it will be useful, but WITHOUT 
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License 
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
  * version 3 for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
@@ -20,18 +21,18 @@
 
 package org.freedesktop.gstreamer;
 
+import org.freedesktop.gstreamer.lowlevel.GType;
+import org.freedesktop.gstreamer.lowlevel.GstMiniObjectAPI;
 import org.freedesktop.gstreamer.lowlevel.GstMiniObjectAPI.MiniObjectStruct;
 import org.freedesktop.gstreamer.lowlevel.GstNative;
 import org.freedesktop.gstreamer.lowlevel.RefCountedObject;
-import org.freedesktop.gstreamer.lowlevel.GstMiniObjectAPI;
 
-import com.sun.jna.NativeLibrary;
 import com.sun.jna.Pointer;
 
 /**
  * Lightweight base class for the GStreamer object hierarchy
  *
- * MiniObject is a baseclass like {@link GObject}, but has been stripped down of 
+ * MiniObject is a baseclass like {@link GObject}, but has been stripped down of
  * features to be fast and small.
  * It offers sub-classing and ref-counting in the same way as GObject does.
  * It has no properties and no signal-support though.
@@ -44,7 +45,16 @@ public class MiniObject extends RefCountedObject {
     public MiniObject(Initializer init) {
         super(init);
     }
-    
+
+    /**
+     * Gives the type value.
+     */
+    public static GType getType(Pointer ptr) {
+    	// Quick getter for GType without allocation
+    	// same as : new MiniObjectStruct(ptr).type
+    	return GType.valueOf(ptr.getNativeLong(0).longValue());
+    }
+
     /**
      * Checks if a mini-object is writable.  A mini-object is writable
      * if the reference count is one and the {@link MiniObjectFlags#READONLY}
@@ -56,44 +66,53 @@ public class MiniObject extends RefCountedObject {
     public boolean isWritable() {
         return gst.gst_mini_object_is_writable(this);
     }
-    
+
     /**
      * Makes a writable instance of this MiniObject.
      * <p> The result is cast to <tt>subclass</tt>.
-     * 
-     * @param subclass the subclass to cast the result to.
-     * @return a writable version of this MiniObject.
+     *
+     * @return a writable version (possibly a duplicate) of this MiniObject.
      */
-    protected <T extends MiniObject> T makeWritable(Class<T> subclass) {
+    protected <T extends MiniObject> T makeWritable() {
         MiniObject result = gst.gst_mini_object_make_writable(this);
         if (result == null) {
-            throw new NullPointerException("Could not make " + subclass.getSimpleName() 
-                    + " writable");
+            throw new NullPointerException("Could not make " + this.getClass().getSimpleName() + " writable");
         }
-        return subclass.cast(result);
+        return (T)result;
     }
-    /*
-     * FIXME: this one returns a new MiniObject, so we need to replace the Pointer
-     * with the new one.  Messy.
-    public void makeWritable() {
-        gst.gst_mini_object_make_writable(this);
+
+    /**
+     * Create a new MiniObject as a copy of the this instance.
+     *
+     * @return the new MiniObject.
+     */
+    public <T extends MiniObject> T copy() {
+    	MiniObject result = gst.gst_mini_object_copy(this);
+        if (result == null) {
+            throw new NullPointerException("Could not make a copy of " + this.getClass().getSimpleName());
+        }
+        return (T)result;
     }
-    */
-    protected void ref() {
+
+    @Override
+	protected void ref() {
         gst.gst_mini_object_ref(this);
     }
-    protected void unref() {
+    
+    @Override
+	protected void unref() {
     	gst.gst_mini_object_unref(this);
     }
-    
+
     public int getRefCount() {
     	final MiniObjectStruct struct = new MiniObjectStruct(handle());
     	return (Integer) struct.readField("refcount");
     }
-    
-    protected void disposeNativeHandle(Pointer ptr) {
+
+    @Override
+	protected void disposeNativeHandle(Pointer ptr) {
     	if (ownsHandle.get()) {
     		gst.gst_mini_object_unref(ptr);
     	}
-    }
+    }    
 }

--- a/src/org/freedesktop/gstreamer/Query.java
+++ b/src/org/freedesktop/gstreamer/Query.java
@@ -52,21 +52,4 @@ public class Query extends MiniObject {
         return ReferenceManager.addKeepAliveReference(gst.gst_query_get_structure(this), this);
     }
     
-    /**
-     * Makes a writable query from this query.
-     * <p>
-     * <b>Note:</b> After calling this method, this Query instance is invalidated
-     * and should no longer be used.
-     * <p>
-     * This should be used like this:
-     * <p>
-     * <code>
-     *  query = query.makeWritable();
-     * </code>
-     * 
-     * @return A new Query that is writable.
-     */
-    public Query makeWritable() {
-        return makeWritable(getClass());
-    }
 }

--- a/src/org/freedesktop/gstreamer/lowlevel/GObjectAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GObjectAPI.java
@@ -20,7 +20,10 @@
 
 package org.freedesktop.gstreamer.lowlevel;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 
 import org.freedesktop.gstreamer.GObject;
 import org.freedesktop.gstreamer.glib.GQuark;
@@ -30,10 +33,8 @@ import com.sun.jna.Callback;
 import com.sun.jna.Library;
 import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
+import com.sun.jna.Structure.ByReference;
 import com.sun.jna.ptr.IntByReference;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 /**
  *
@@ -114,7 +115,7 @@ public interface GObjectAPI extends Library {
     /* 
      * Basic Type Structures
      */
-    public static final class GTypeClass extends com.sun.jna.Structure {
+    public static class GTypeClass extends com.sun.jna.Structure {
 
         /*< private >*/
         public volatile GType g_type;
@@ -124,11 +125,16 @@ public interface GObjectAPI extends Library {
             return Collections.singletonList("g_type");
         }
     }
+    
+    public static final class GTypeClassByReference extends GTypeClass implements ByReference {
+    	//
+    }
+
 
     public static final class GTypeInstance extends com.sun.jna.Structure {
 
         /*< private >*/
-        public volatile Pointer g_class;
+    	public volatile GTypeClassByReference g_class; 
         
         @Override
         protected List<String> getFieldOrder() {
@@ -144,8 +150,8 @@ public interface GObjectAPI extends Library {
         public GObjectStruct(GObject obj) {
             this(obj.handle());
         }
-        public GObjectStruct(Pointer handle) {
-            useMemory(handle);
+        public GObjectStruct(Pointer ptr) {
+            super(ptr);
             read();
         }
         
@@ -196,7 +202,7 @@ public interface GObjectAPI extends Library {
 
         public GObjectClass() {}
         public GObjectClass(Pointer ptr) {
-            useMemory(ptr);
+            super(ptr);
             read();
         }
         
@@ -236,7 +242,7 @@ public interface GObjectAPI extends Library {
             clear();
         }
         public GTypeInfo(Pointer ptr) { 
-            useMemory(ptr); 
+            super(ptr); 
             read();
         }
         /* interface types, classed types, instantiated types */
@@ -272,7 +278,12 @@ public interface GObjectAPI extends Library {
     	public abstract Object getMaximum();
     	public abstract Object getDefault();
     	
-        public GParamSpecTypeSpecific() { clear(); }
+        public GParamSpecTypeSpecific() { 
+        	clear(); 
+        }
+        public GParamSpecTypeSpecific(Pointer ptr) {
+        	super(ptr);
+        }
     }
     public static final class GParamSpecBoolean extends GParamSpecTypeSpecific {
     	public volatile GParamSpec parent_instance;
@@ -283,7 +294,7 @@ public interface GObjectAPI extends Library {
     	public Object getDefault() { return default_value; }
     	
         public GParamSpecBoolean(Pointer ptr) {
-            useMemory(ptr);
+            super(ptr);
             read();
         }
         
@@ -305,7 +316,7 @@ public interface GObjectAPI extends Library {
     	public Object getDefault() { return default_value; }
     	
         public GParamSpecInt(Pointer ptr) {
-            useMemory(ptr);
+            super(ptr);
             read();
         }
         
@@ -329,7 +340,7 @@ public interface GObjectAPI extends Library {
     	public Object getDefault() { return ((long)default_value)&0xffffff; }
     	
         public GParamSpecUInt(Pointer ptr) {
-            useMemory(ptr);
+            super(ptr);
             read();
         }
         
@@ -352,7 +363,7 @@ public interface GObjectAPI extends Library {
     	public Object getDefault() { return default_value; }
     	
         public GParamSpecChar(Pointer ptr) {
-            useMemory(ptr);
+            super(ptr);
             read();
         }
         
@@ -375,7 +386,7 @@ public interface GObjectAPI extends Library {
     	public Object getDefault() { return ((short)default_value)&0xff; }
     	
         public GParamSpecUChar(Pointer ptr) {
-            useMemory(ptr);
+            super(ptr);
             read();
         }
         
@@ -398,7 +409,7 @@ public interface GObjectAPI extends Library {
     	public Object getDefault() { return default_value; }
     	
         public GParamSpecLong(Pointer ptr) {
-            useMemory(ptr);
+            super(ptr);
             read();
         }
         
@@ -421,7 +432,7 @@ public interface GObjectAPI extends Library {
     	public Object getDefault() { return default_value; }
     	
         public GParamSpecInt64(Pointer ptr) {
-            useMemory(ptr);
+            super(ptr);
             read();
         }
         
@@ -445,7 +456,7 @@ public interface GObjectAPI extends Library {
     	public Object getDefault() { return default_value; }
     	
         public GParamSpecFloat(Pointer ptr) {
-            useMemory(ptr);
+            super(ptr);
             read();
         }
         
@@ -469,7 +480,7 @@ public interface GObjectAPI extends Library {
     	public Object getDefault() { return default_value; }
     	
         public GParamSpecDouble(Pointer ptr) {
-            useMemory(ptr);
+            super(ptr);
             read();
         }
         
@@ -495,7 +506,7 @@ public interface GObjectAPI extends Library {
     	public Object getDefault() { return default_value; }
     	
         public GParamSpecString(Pointer ptr) {
-            useMemory(ptr);
+            super(ptr);
             read();
         }
         
@@ -525,7 +536,7 @@ public interface GObjectAPI extends Library {
             clear();
         }
         public GParamSpec(Pointer ptr) {
-            useMemory(ptr);
+            super(ptr);
             read();
         }
         

--- a/src/org/freedesktop/gstreamer/lowlevel/GstMiniObjectAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GstMiniObjectAPI.java
@@ -1,8 +1,9 @@
-/* 
+/*
+ * Copyright (c) 2016 Christophe Lafolet
  * Copyright (c) 2014 Tom Greenwood <tgreenwood@cafex.com>
  * Copyright (c) 2009 Levente Farkas
  * Copyright (c) 2007, 2008 Wayne Meissner
- * 
+ *
  * This file is part of gstreamer-java.
  *
  * This code is free software: you can redistribute it and/or modify it under
@@ -20,15 +21,16 @@
 
 package org.freedesktop.gstreamer.lowlevel;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.freedesktop.gstreamer.MiniObject;
-import org.freedesktop.gstreamer.lowlevel.GObjectAPI.GTypeInstance;
+import org.freedesktop.gstreamer.glib.GQuark;
+import org.freedesktop.gstreamer.lowlevel.GlibAPI.GDestroyNotify;
 import org.freedesktop.gstreamer.lowlevel.annotations.CallerOwnsReturn;
 import org.freedesktop.gstreamer.lowlevel.annotations.Invalidate;
 
-import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * GstMiniObject functions
@@ -39,15 +41,17 @@ public interface GstMiniObjectAPI extends com.sun.jna.Library {
     void gst_mini_object_ref(MiniObject ptr);
     void gst_mini_object_unref(MiniObject ptr);
     void gst_mini_object_unref(Pointer ptr);
-    @CallerOwnsReturn Pointer ptr_gst_mini_object_copy(MiniObject mini_object);
+
+    @CallerOwnsReturn MiniObject gst_mini_object_make_writable(@Invalidate MiniObject mini_object);
     @CallerOwnsReturn MiniObject gst_mini_object_copy(MiniObject mini_object);
     boolean gst_mini_object_is_writable(MiniObject mini_object);
-    /* FIXME - invalidate the argument, and return a MiniObject */
-    @CallerOwnsReturn Pointer ptr_gst_mini_object_make_writable(@Invalidate MiniObject mini_object);
-    @CallerOwnsReturn MiniObject gst_mini_object_make_writable(@Invalidate MiniObject mini_object);
-    
+
+    void gst_mini_object_set_qdata(MiniObject mini_object, GQuark quark, Object data, GDestroyNotify destroyCallback);
+    Pointer gst_mini_object_get_qdata(MiniObject mini_object, GQuark quark);
+    Pointer gst_mini_object_steal_qdata(MiniObject mini_object, GQuark quark);
+
     public static final class MiniObjectStruct extends com.sun.jna.Structure {
-        public volatile NativeLong type; // GType - this is a guess from http://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer/html/gstreamer-GstMiniObject.html#GstMiniObject
+        public volatile GType type; 
         public volatile int refcount;
         public volatile int lockstate;
         public volatile int flags;
@@ -56,12 +60,11 @@ public interface GstMiniObjectAPI extends com.sun.jna.Library {
         public volatile Pointer freeFn;
         public volatile int n_qdata; // Private parts - there for alignment
         public volatile Pointer qdata;
-        
+
         /** Creates a new instance of GstMiniObjectStructure */
         public MiniObjectStruct() {}
         public MiniObjectStruct(Pointer ptr) {
-            useMemory(ptr);
-            read();
+            super(ptr);
         }
 
         @Override
@@ -71,7 +74,5 @@ public interface GstMiniObjectAPI extends com.sun.jna.Library {
                 "copyFn", "disposeFn", "freeFn", "n_qdata", "qdata"
             });
         }
-        
-        
     }
 }

--- a/src/org/freedesktop/gstreamer/lowlevel/GstTypes.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GstTypes.java
@@ -1,8 +1,9 @@
-/* 
+/*
+ * Copyright (c) 2016 Christophe Lafolet
  * Copyright (c) 2009 Levente Farkas
  * Copyright (c) 2008 Andres Colubri
  * Copyright (c) 2007 Wayne Meissner
- * 
+ *
  * This file is part of gstreamer-java.
  *
  * This code is free software: you can redistribute it and/or modify it under
@@ -20,90 +21,67 @@
 
 package org.freedesktop.gstreamer.lowlevel;
 
-import static org.freedesktop.gstreamer.lowlevel.GObjectAPI.GOBJECT_API;
-
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import com.sun.jna.Pointer;
 
 /**
  *
  */
 public class GstTypes {
     private static final Logger logger = Logger.getLogger(GstTypes.class.getName());
-    
-    private static final Map<String, Class<? extends NativeObject>> gTypeNameMap
-        = new HashMap<String, Class<? extends NativeObject>>();
-    private static final Map<Pointer, Class<? extends NativeObject>> gTypeInstanceMap
-        = new ConcurrentHashMap<Pointer, Class<? extends NativeObject>>();
-    
+
+    private static final Map<String, Class<? extends NativeObject>> gtypeNameMap
+        = new ConcurrentHashMap<String, Class<? extends NativeObject>>();
+
     private GstTypes() {}
+    
     /**
-     * Register a new class into the gTypeNameMap.
+     * Register a class with its GType name
      */
     public static void registerType(Class<? extends NativeObject> cls, String gTypeName) {
-   		gTypeNameMap.put(gTypeName, cls);
+   		gtypeNameMap.put(gTypeName, cls);
     }
+    
     /**
      * Retrieve the class of a GType
-     * 
+     *
      * @param gType The type of Class
      * @return The Class of the desired type.
      */
-    public static Class<? extends NativeObject> find(GType gType) {
-        logger.entering("GstTypes", "find", gType);
-        return gTypeNameMap.get(GOBJECT_API.g_type_name(gType));
-    }
-    /**
-     * Retrieve the class of a GType Name
-     * 
-     * @param gTypeName The type name of Class
-     * @return The Class of the desired type.
-     */
-    public static Class<? extends NativeObject> find(String gTypeName) {
-        logger.entering("GstTypes", "find", gTypeName);
-        return gTypeNameMap.get(gTypeName);
-    }
+    public static final Class<? extends NativeObject> classFor(final GType gType) {
+    	final String gTypeName = gType.getTypeName();
 
-    public static final boolean isGType(Pointer p, long type) {
-        return getGType(p).longValue() == type;
-    }
-    public static final GType getGType(Pointer ptr) {        
-        // Retrieve ptr->g_class
-        Pointer g_class = ptr.getPointer(0);
-        // Now return g_class->gtype
-        return GType.valueOf(g_class.getNativeLong(0).longValue());
-    }
-    public static final Class<? extends NativeObject> classFor(Pointer ptr) {
-        Pointer g_class = ptr.getPointer(0);
-        Class<? extends NativeObject> cls = gTypeInstanceMap.get(g_class);
+    	// Is this GType still registered in the map ? 
+    	Class<? extends NativeObject> cls = gtypeNameMap.get(gTypeName);
         if (cls != null) {
-            return cls;
+        	return cls;
         }
 
-        GType type = GType.valueOf(g_class.getNativeLong(0).longValue());
-        logger.finer("Type of " + ptr + " = " + type);
-        while (cls == null && !type.equals(GType.OBJECT) && !type.equals(GType.INVALID)) {
-            cls = find(type);
+        // Search for a parent class registration
+        GType type = gType.getParentType();
+        while (!type.equals(GType.OBJECT) && !type.equals(GType.INVALID)) {
+           	cls = gtypeNameMap.get(type.getTypeName());
             if (cls != null) {
-                logger.finer("Found type of " + ptr + " = " + cls);
-                gTypeInstanceMap.put(g_class, cls);
-                break;
+                if (GstTypes.logger.isLoggable(Level.FINER)) {
+                    GstTypes.logger.finer("Found type of " + gType + " = " + cls);
+                }
+                gtypeNameMap.put(gTypeName, cls);
+                return cls;
             }
-            type = GOBJECT_API.g_type_parent(type);
+        	type = type.getParentType();
         }
-        return cls;
+
+        // Should never appeared
+        throw new IllegalStateException("Could not find a registered class for " + gType);
+
     }
-    public static final Class<? extends NativeObject> classFor(GType type) {
-        return find(type);
-    }
+
     public static final GType typeFor(Class<? extends NativeObject> cls) {
-        for (Map.Entry<String, Class<? extends NativeObject>> e : gTypeNameMap.entrySet()) {
+        for (Map.Entry<String, Class<? extends NativeObject>> e : gtypeNameMap.entrySet()) {
             if (e.getValue().equals(cls)) {
-                return GOBJECT_API.g_type_from_name(e.getKey());
+                return GType.valueOf(e.getKey());
             }
         }
         return GType.INVALID;


### PR DESCRIPTION
Since GStreamer 1.0, MiniObject contains only a GType.
GstTypes shall not expect a GClassType but a GType.

MiniObject : add a generic copy.
