### PR TITLE
GType : Remove API and use directly GObjectAPI.GOBJECT_API

### DIFF
--- a/src/org/freedesktop/gstreamer/lowlevel/GType.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GType.java
@@ -35,9 +35,6 @@ public class GType extends IntegerType {
     public static final int SIZE = Native.SIZE_T_SIZE;
     private static final int G_TYPE_FUNDAMENTAL_SHIFT = 2;
 
-    private interface API extends GObjectAPI {}
-    private static final API gst = GstNative.load(API.class);
-
     private static final Map<Long, GType> gTypeByValues = new ConcurrentHashMap<Long, GType>();
     private static final Map<String, GType> gTypeByNames = new ConcurrentHashMap<String, GType>();
     
@@ -98,9 +95,9 @@ public class GType extends IntegerType {
     public static GType valueOf(String typeName) {
     	GType result = gTypeByNames.get(typeName);
     	if (result == null) {
-    		result = gst.g_type_from_name(typeName);
+    		result = GObjectAPI.GOBJECT_API.g_type_from_name(typeName);
     		if (result.equals(INVALID)) {
-    			// no type has been registered yet
+    			throw new IllegalStateException("No GType registered for this name");
     		} else {
         		gTypeByNames.put(typeName, result);
         		result.name = typeName;
@@ -137,13 +134,13 @@ public class GType extends IntegerType {
      */
     public GType getParentType() {
     	if (this.parent == null) 
-    		this.parent = gst.g_type_parent(this);
+    		this.parent = GObjectAPI.GOBJECT_API.g_type_parent(this);
     	return this.parent;
     }
     
     public String getTypeName() {
     	if (this.name == null) {
-    		this.name = gst.g_type_name(this);
+    		this.name = GObjectAPI.GOBJECT_API.g_type_name(this);
     		gTypeByNames.put(this.name, this);
     	}
     	return this.name;    	


### PR DESCRIPTION
1/ To correct https://github.com/gstreamer-java/gst1-java-core/issues/41 for GType.
2/ GType.valueOf(String typeName) return now an IllegalStateException() if g_type_from_name() can't retrieve a GType