### PR TITLE
Fixed typo on GstBinAPI mapping of gst_debug_bin_to_dot_file_with_ts

### DIFF
--- a/src/org/freedesktop/gstreamer/Bin.java
+++ b/src/org/freedesktop/gstreamer/Bin.java
@@ -261,7 +261,7 @@ public class Bin extends Element {
      */
     public void debugToDotFile(int details, String fileName, boolean timestampFileName) {
     	if (timestampFileName)
-    		GSTBIN_API._gst_debug_bin_to_dot_file_with_ts(this, details, fileName);
+    		GSTBIN_API.gst_debug_bin_to_dot_file_with_ts(this, details, fileName);
     	else 
     		GSTBIN_API.gst_debug_bin_to_dot_file(this, details, fileName);	
     }

--- a/src/org/freedesktop/gstreamer/lowlevel/GstBinAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GstBinAPI.java
@@ -52,6 +52,6 @@ public interface GstBinAPI extends com.sun.jna.Library {
 
     //Debugging
     void gst_debug_bin_to_dot_file (Bin bin, int details, String file_name);
-    void _gst_debug_bin_to_dot_file_with_ts (Bin bin, int details, String file_name);
+    void gst_debug_bin_to_dot_file_with_ts (Bin bin, int details, String file_name);
     
 }


### PR DESCRIPTION
I was getting linker errors while trying to use Bin.debugToDotFile with timesptampFileName=true. 
I tracked it down to a typo on GstBinAPI mapping. Now it works as expected.