### PR TITLE
Allow to retrieve NativeObjects from GType.BOXED values

### DIFF
--- a/src/org/freedesktop/gstreamer/lowlevel/GValueAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GValueAPI.java
@@ -166,7 +166,7 @@ public interface GValueAPI extends Library {
                 Class<? extends NativeObject> cls = GstTypes.classFor(g_type);
                 if (cls != null) {
                     Pointer ptr = GVALUE_API.g_value_get_boxed(this);
-                    return NativeObject.objectFor(ptr, cls, -1, true);
+                    return NativeObject.objectFor(ptr, cls, 1, true);
                 }
             }
             return GVALUE_API.g_value_get_object(this);        

--- a/src/org/freedesktop/gstreamer/lowlevel/GValueAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GValueAPI.java
@@ -162,8 +162,14 @@ public interface GValueAPI extends Library {
             } else if (g_type.equals(GType.STRING)) { return toJavaString();
 //            } else if (g_type.equals(GType.OBJECT)) { return toObject();
             } else if (g_type.equals(GType.POINTER)) { return toPointer();
+            } else if (g_type.getParentType().equals(GType.BOXED)) {
+                Class<? extends NativeObject> cls = GstTypes.classFor(g_type);
+                if (cls != null) {
+                    Pointer ptr = GVALUE_API.g_value_get_boxed(this);
+                    return NativeObject.objectFor(ptr, cls, -1, true);
+                }
             }
-            return GVALUE_API.g_value_get_object(this);
+            return GVALUE_API.g_value_get_object(this);        
         }
         
         public Integer toInt() {


### PR DESCRIPTION
When trying to retrieve a Caps object from a CapsEvent, I kept getting a gstreamer assertion error complaining about structure.getValue("caps") not being an object. This should fix that and should allow to retrieve boxed NativeObjects from any field in a Gstreamer structure.