### PR TITLE
Native bindings for GIO GSocket API

### DIFF
--- a/src/org/freedesktop/gstreamer/GInetSocketAddress.java
+++ b/src/org/freedesktop/gstreamer/GInetSocketAddress.java
@@ -1,0 +1,33 @@
+package org.freedesktop.gstreamer;
+
+import org.freedesktop.gstreamer.glib.GInetAddress;
+import org.freedesktop.gstreamer.glib.GSocketAddress;
+import org.freedesktop.gstreamer.lowlevel.GioAPI;
+
+import com.sun.jna.Pointer;
+
+public class GInetSocketAddress extends GSocketAddress{
+
+	public static final String GTYPE_NAME = "GInetSocketAddress";
+	
+	
+	protected static GInetSocketAddress create(String address, int port) {
+		Pointer nativePointer = GioAPI.g_inet_socket_address_new_from_string(address, port);
+		if (nativePointer == null) {
+			throw new GstException("Can not create "+GInetSocketAddress.class.getSimpleName()+" for "+address+":"+port+", please check that the IP address is valid, with format x.x.x.x");
+		}
+		return new GInetSocketAddress(initializer(nativePointer));
+	}
+	
+	public GInetSocketAddress(Initializer init) {
+		super(init);
+	}
+
+	public Integer getPort() {
+		return (Integer) get("port");
+	}
+	
+	public GInetAddress getAddress() {
+		return (GInetAddress) get("address");
+	}
+}

--- a/src/org/freedesktop/gstreamer/GInetSocketAddress.java
+++ b/src/org/freedesktop/gstreamer/GInetSocketAddress.java
@@ -11,12 +11,16 @@ public class GInetSocketAddress extends GSocketAddress{
 	public static final String GTYPE_NAME = "GInetSocketAddress";
 	
 	
-	protected static GInetSocketAddress create(String address, int port) {
+	protected static Initializer createRawAddress(String address, int port) {
 		Pointer nativePointer = GioAPI.g_inet_socket_address_new_from_string(address, port);
 		if (nativePointer == null) {
 			throw new GstException("Can not create "+GInetSocketAddress.class.getSimpleName()+" for "+address+":"+port+", please check that the IP address is valid, with format x.x.x.x");
 		}
-		return new GInetSocketAddress(initializer(nativePointer));
+		return initializer(nativePointer);
+	}
+	
+	public GInetSocketAddress(String address, int port)  {
+		this(createRawAddress(address, port));
 	}
 	
 	public GInetSocketAddress(Initializer init) {

--- a/src/org/freedesktop/gstreamer/GSocket.java
+++ b/src/org/freedesktop/gstreamer/GSocket.java
@@ -13,7 +13,7 @@ public class GSocket extends GObject{
 
 	public static final String GTYPE_NAME = "GSocket";
 	
-	public static GSocket create(GSocketFamily family, GSocketType type, GSocketProtocol protocol) throws GstException {
+	public static Initializer makeRawSocket(GSocketFamily family, GSocketType type, GSocketProtocol protocol) throws GstException {
 		GErrorStruct reference = new GErrorStruct();
 		GErrorStruct[] errorArray = (GErrorStruct[]) reference.toArray(1);
 		Pointer socketPointer = GioAPI.g_socket_new(family.toGioValue(), type.toGioValue(), protocol.toGioValue(), reference.getPointer());
@@ -21,17 +21,13 @@ public class GSocket extends GObject{
 			errorArray[0].read();
 			throw new GstException(new GError(errorArray[0]));
 		}
-		return new GSocket(initializer(socketPointer));
+		return initializer(socketPointer);
 	}
 	
-	public static GSocket createDefaultUdpSocket() {
-		return create(GSocketFamily.IPV4, GSocketType.DATAGRAM, GSocketProtocol.UDP);
+	public GSocket(GSocketFamily family, GSocketType type, GSocketProtocol protocol) throws GstException {
+		this(makeRawSocket(family, type, protocol));
 	}
-
-	public static GSocket createDefaultUdpSocket(String bindAddress, int bindPort) {
-		return create(GSocketFamily.IPV4, GSocketType.DATAGRAM, GSocketProtocol.UDP).bind(bindAddress, bindPort);
-	}
-
+	
 	public GSocket(Initializer init) {
 		super(init);
 	}

--- a/src/org/freedesktop/gstreamer/GSocket.java
+++ b/src/org/freedesktop/gstreamer/GSocket.java
@@ -1,0 +1,89 @@
+package org.freedesktop.gstreamer;
+
+import org.freedesktop.gstreamer.glib.GCancellable;
+import org.freedesktop.gstreamer.glib.GSocketFamily;
+import org.freedesktop.gstreamer.glib.GSocketProtocol;
+import org.freedesktop.gstreamer.glib.GSocketType;
+import org.freedesktop.gstreamer.lowlevel.GioAPI;
+import org.freedesktop.gstreamer.lowlevel.GstAPI.GErrorStruct;
+
+import com.sun.jna.Pointer;
+
+public class GSocket extends GObject{
+
+	public static final String GTYPE_NAME = "GSocket";
+	
+	public static GSocket create(GSocketFamily family, GSocketType type, GSocketProtocol protocol) throws GstException {
+		GErrorStruct reference = new GErrorStruct();
+		GErrorStruct[] errorArray = (GErrorStruct[]) reference.toArray(1);
+		Pointer socketPointer = GioAPI.g_socket_new(family.toGioValue(), type.toGioValue(), protocol.toGioValue(), reference.getPointer());
+		if (socketPointer == null) {
+			errorArray[0].read();
+			throw new GstException(new GError(errorArray[0]));
+		}
+		return new GSocket(initializer(socketPointer));
+	}
+	
+	public static GSocket createDefaultUdpSocket() {
+		return create(GSocketFamily.IPV4, GSocketType.DATAGRAM, GSocketProtocol.UDP);
+	}
+
+	public static GSocket createDefaultUdpSocket(String bindAddress, int bindPort) {
+		return create(GSocketFamily.IPV4, GSocketType.DATAGRAM, GSocketProtocol.UDP).bind(bindAddress, bindPort);
+	}
+
+	public GSocket(Initializer init) {
+		super(init);
+	}
+	
+	public GSocket bind(String address, int port) {
+		GInetSocketAddress boundAddress = GInetSocketAddress.create(address, port);
+		GErrorStruct reference = new GErrorStruct();
+		GErrorStruct[] errorArray = (GErrorStruct[]) reference.toArray(1);
+		if ( ! GioAPI.g_socket_bind(getNativeAddress(), boundAddress.getNativeAddress(), true, reference.getPointer()) ) {
+			errorArray[0].read();
+			throw new GstException(new GError(errorArray[0]));
+		}
+		return this;
+	}
+	
+	public void connect(String address, int port) {
+		GInetSocketAddress connectedAddress = GInetSocketAddress.create(address, port);
+		GErrorStruct reference = new GErrorStruct();
+		GErrorStruct[] errorArray = (GErrorStruct[]) reference.toArray(1);
+		if ( ! GioAPI.g_socket_connect(getNativeAddress(), connectedAddress.getNativeAddress(), new GCancellable().getNativeAddress(), reference.getPointer()) ) {
+			errorArray[0].read();
+			throw new GstException(new GError(errorArray[0]));
+		}
+	}
+	
+	public GInetSocketAddress getLocalAddress() {
+		return (GInetSocketAddress) get("local-address");
+	}
+
+	public GInetSocketAddress getRemoteAddress() {
+		return (GInetSocketAddress) get("remote-address");
+	}
+
+	public GSocketType getSocketType() {
+		return GSocketType.fromGioValue((Integer) get("type"));
+	}
+
+	public GSocketFamily getSocketFamily() {
+		return GSocketFamily.fromGioValue((Integer) get("family"));
+	}
+
+	public GSocketProtocol getSocketProtocol() {
+		return GSocketProtocol.fromGioValue((Integer) get("protocol"));
+	}
+
+	public boolean isBlocking() {
+		return (Boolean) get("blocking");
+	}
+	
+	public Integer getFD() {
+		return (Integer) get("fd");
+	}
+	
+	
+}

--- a/src/org/freedesktop/gstreamer/GSocket.java
+++ b/src/org/freedesktop/gstreamer/GSocket.java
@@ -33,7 +33,7 @@ public class GSocket extends GObject{
 	}
 	
 	public GSocket bind(String address, int port) {
-		GInetSocketAddress boundAddress = GInetSocketAddress.create(address, port);
+		GInetSocketAddress boundAddress = new GInetSocketAddress(address, port);
 		GErrorStruct reference = new GErrorStruct();
 		GErrorStruct[] errorArray = (GErrorStruct[]) reference.toArray(1);
 		if ( ! GioAPI.g_socket_bind(getNativeAddress(), boundAddress.getNativeAddress(), true, reference.getPointer()) ) {
@@ -44,7 +44,7 @@ public class GSocket extends GObject{
 	}
 	
 	public void connect(String address, int port) {
-		GInetSocketAddress connectedAddress = GInetSocketAddress.create(address, port);
+		GInetSocketAddress connectedAddress = new GInetSocketAddress(address, port);
 		GErrorStruct reference = new GErrorStruct();
 		GErrorStruct[] errorArray = (GErrorStruct[]) reference.toArray(1);
 		if ( ! GioAPI.g_socket_connect(getNativeAddress(), connectedAddress.getNativeAddress(), new GCancellable().getNativeAddress(), reference.getPointer()) ) {

--- a/src/org/freedesktop/gstreamer/Gst.java
+++ b/src/org/freedesktop/gstreamer/Gst.java
@@ -19,6 +19,8 @@
 
 package org.freedesktop.gstreamer;
 
+import static org.freedesktop.gstreamer.lowlevel.GstAPI.GST_API;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -34,11 +36,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
-import com.sun.jna.Memory;
-import com.sun.jna.Pointer;
-import com.sun.jna.ptr.IntByReference;
-import com.sun.jna.ptr.PointerByReference;
-
 import org.freedesktop.gstreamer.elements.AppSink;
 import org.freedesktop.gstreamer.elements.AppSrc;
 import org.freedesktop.gstreamer.elements.BaseSink;
@@ -48,6 +45,8 @@ import org.freedesktop.gstreamer.elements.DecodeBin;
 import org.freedesktop.gstreamer.elements.PlayBin;
 import org.freedesktop.gstreamer.elements.URIDecodeBin;
 import org.freedesktop.gstreamer.glib.GDate;
+import org.freedesktop.gstreamer.glib.GInetAddress;
+import org.freedesktop.gstreamer.glib.GSocketAddress;
 import org.freedesktop.gstreamer.glib.MainContextExecutorService;
 import org.freedesktop.gstreamer.lowlevel.GMainContext;
 import org.freedesktop.gstreamer.lowlevel.GValueAPI.GValue;
@@ -58,7 +57,10 @@ import org.freedesktop.gstreamer.lowlevel.GstControlSourceAPI.ValueArray;
 import org.freedesktop.gstreamer.lowlevel.GstTypes;
 import org.freedesktop.gstreamer.lowlevel.NativeObject;
 
-import static org.freedesktop.gstreamer.lowlevel.GstAPI.GST_API;
+import com.sun.jna.Memory;
+import com.sun.jna.Pointer;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.ptr.PointerByReference;
 
 /**
  * Media library supporting arbitrary formats and filter graphs.
@@ -446,6 +448,10 @@ public final class Gst {
     @SuppressWarnings("rawtypes")
 	private static Class[] nativeClasses = {
 		GDate.class,
+		GInetAddress.class,
+		GSocket.class,
+		GSocketAddress.class,
+		GInetSocketAddress.class,
 		GValue.class,
 		GValueArray.class,
 		TimedValue.class,

--- a/src/org/freedesktop/gstreamer/glib/GCancellable.java
+++ b/src/org/freedesktop/gstreamer/glib/GCancellable.java
@@ -1,0 +1,18 @@
+package org.freedesktop.gstreamer.glib;
+
+import org.freedesktop.gstreamer.GObject;
+import org.freedesktop.gstreamer.lowlevel.GioAPI;
+
+public class GCancellable extends GObject{
+
+	public static final String GTYPE_NAME = "GCancellable";
+
+	public GCancellable() {
+		this(initializer(GioAPI.g_cancellable_new()));
+	}
+	
+	public GCancellable(Initializer init) {
+		super(init);
+	}
+
+}

--- a/src/org/freedesktop/gstreamer/glib/GInetAddress.java
+++ b/src/org/freedesktop/gstreamer/glib/GInetAddress.java
@@ -1,0 +1,18 @@
+package org.freedesktop.gstreamer.glib;
+
+import org.freedesktop.gstreamer.GObject;
+import org.freedesktop.gstreamer.lowlevel.GioAPI;
+
+public class GInetAddress extends GObject{
+
+	public static final String GTYPE_NAME = "GInetAddress";
+
+	public GInetAddress(Initializer init) {
+		super(init);
+	}
+
+	public String getAddress() {
+		return GioAPI.g_inet_address_to_string(getNativeAddress());
+	}
+	
+}

--- a/src/org/freedesktop/gstreamer/glib/GSocketAddress.java
+++ b/src/org/freedesktop/gstreamer/glib/GSocketAddress.java
@@ -1,0 +1,18 @@
+package org.freedesktop.gstreamer.glib;
+
+import org.freedesktop.gstreamer.GObject;
+
+public class GSocketAddress extends GObject{
+
+	public static final String GTYPE_NAME = "GSocketAddress";
+
+	public GSocketAddress(Initializer init) {
+		super(init);
+	}
+
+	public GSocketFamily getFamily() {
+		return GSocketFamily.fromGioValue((Integer) get("family"));
+	}
+
+	
+}

--- a/src/org/freedesktop/gstreamer/glib/GSocketFamily.java
+++ b/src/org/freedesktop/gstreamer/glib/GSocketFamily.java
@@ -1,0 +1,36 @@
+package org.freedesktop.gstreamer.glib;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.freedesktop.gstreamer.lowlevel.GlibAPI;
+
+public enum GSocketFamily {
+	
+	INVALID	(0x00),
+	UNIX		(GlibAPI.GLIB_SYSDEF_AF_UNIX),
+	IPV4		(GlibAPI.GLIB_SYSDEF_AF_INET),
+	IPV6		(GlibAPI.GLIB_SYSDEF_AF_INET6);
+
+	private static final Map<Integer,GSocketFamily> fastResolveMap = new HashMap<Integer,GSocketFamily>();
+	static {
+		for(GSocketFamily dataUnitType : values()) {
+			fastResolveMap.put(dataUnitType.toGioValue(), dataUnitType);
+		}
+	}
+	
+	public static GSocketFamily fromGioValue(int gioValue) {
+		return fastResolveMap.get(gioValue);
+	}
+
+	private int gioValue;
+
+	private GSocketFamily(int gioValue) {
+		this.gioValue = gioValue;
+	}
+
+	public int toGioValue() {
+		return gioValue;
+	}
+
+}

--- a/src/org/freedesktop/gstreamer/glib/GSocketProtocol.java
+++ b/src/org/freedesktop/gstreamer/glib/GSocketProtocol.java
@@ -1,0 +1,34 @@
+package org.freedesktop.gstreamer.glib;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum GSocketProtocol {
+	UNKNOWN (-1),
+	DEFAULT (0),
+	TCP     (6),
+	UDP     (17),
+	SCTP 	(132);
+
+	private static final Map<Integer,GSocketProtocol> fastResolveMap = new HashMap<Integer,GSocketProtocol>();
+	static {
+		for(GSocketProtocol dataUnitType : values()) {
+			fastResolveMap.put(dataUnitType.toGioValue(), dataUnitType);
+		}
+	}
+
+	public static GSocketProtocol fromGioValue(int gioValue) {
+		return fastResolveMap.get(gioValue);
+	}
+
+	private int gioValue;
+
+	private GSocketProtocol(int gioValue) {
+		this.gioValue = gioValue;
+	}
+
+	public int toGioValue() {
+		return gioValue;
+	}
+
+}

--- a/src/org/freedesktop/gstreamer/glib/GSocketType.java
+++ b/src/org/freedesktop/gstreamer/glib/GSocketType.java
@@ -1,0 +1,33 @@
+package org.freedesktop.gstreamer.glib;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum GSocketType {
+	INVALID		(0),
+	STREAM		(1),
+	DATAGRAM	(2),
+	SEQPACKET	(3);
+
+	private static final Map<Integer,GSocketType> fastResolveMap = new HashMap<Integer,GSocketType>();
+	static {
+		for(GSocketType dataUnitType : values()) {
+			fastResolveMap.put(dataUnitType.toGioValue(), dataUnitType);
+		}
+	}
+	
+	public static GSocketType fromGioValue(int gioValue) {
+		return fastResolveMap.get(gioValue);
+	}
+
+	private int gioValue;
+
+	private GSocketType(int gioValue) {
+		this.gioValue = gioValue;
+	}
+
+	public int toGioValue() {
+		return gioValue;
+	}
+
+}

--- a/src/org/freedesktop/gstreamer/lowlevel/GioAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GioAPI.java
@@ -1,0 +1,30 @@
+package org.freedesktop.gstreamer.lowlevel;
+
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+
+public class GioAPI {
+	
+	static {
+		Native.register("gio-2.0");
+	}
+
+	// GInetAddress
+	public static native String g_inet_address_to_string(Pointer gInetAddress);
+
+	// GstSocketAddress
+	public static native Pointer g_inet_socket_address_new_from_string(String address, int port);
+	
+	// GstSocket
+	public static native Pointer g_socket_new(int gSocketFamilyEnumValue, int gSocketTypeEnumValue, int gSocketProtcolEnumValue, Pointer gErrorStructArrayPointer);
+	public static native boolean g_socket_bind(Pointer gSocketPointer, Pointer gSocketAddressPointer, boolean allowReuse, Pointer gErrorStructArrayPointer);
+	public static native boolean g_socket_connect(Pointer gSocketPointer, Pointer gSocketAddressPointer, Pointer gCancellablePointer, Pointer gErrorStructArrayPointer);
+	
+	// GCancellable
+	public static native Pointer g_cancellable_new();
+
+
+	
+	
+	
+}

--- a/src/org/freedesktop/gstreamer/lowlevel/GlibAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GlibAPI.java
@@ -39,6 +39,11 @@ public interface GlibAPI extends Library {
     		new HashMap<String, Object>() {{
     			put(Library.OPTION_TYPE_MAPPER, new GTypeMapper());
     		}});
+	
+	public static final int GLIB_SYSDEF_AF_UNIX  = 1;
+	public static final int GLIB_SYSDEF_AF_INET  = 2;
+	public static final int GLIB_SYSDEF_AF_INET6 = 23;
+
     Pointer g_main_loop_new(GMainContext context, boolean running);
     void g_main_loop_run(MainLoop loop);
     boolean g_main_loop_is_running(MainLoop loop);


### PR DESCRIPTION
 Added support for GIO GSocket API. This simplifies things when handling
the socket and used-socket properties on udpsink and udpsrc elements.
This property handling is needed for sending and receiving simultaneous RTP streams using the same socket.