### PR TITLE
correct bug in GstTypes

### DIFF
--- a/src/org/freedesktop/gstreamer/lowlevel/GstTypes.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GstTypes.java
@@ -67,7 +67,11 @@ public class GstTypes {
                 if (GstTypes.logger.isLoggable(Level.FINER)) {
                     GstTypes.logger.finer("Found type of " + gType + " = " + cls);
                 }
-                gtypeNameMap.put(gTypeName, cls);
+                
+                // The following line is an optimisation but not compatible with current implementation of GstTypes.typeFor()
+                // Uncomment the following line after refactoring of GstTypes.typeFor()
+                // gtypeNameMap.put(gTypeName, cls);
+                
                 return cls;
             }
         	type = type.getParentType();

--- a/src/org/freedesktop/gstreamer/lowlevel/GstTypes.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GstTypes.java
@@ -81,6 +81,7 @@ public class GstTypes {
         return null;
     }
 
+    //TODO : need refactoring to take into account derived class
     public static final GType typeFor(Class<? extends NativeObject> cls) {
         for (Map.Entry<String, Class<? extends NativeObject>> e : gtypeNameMap.entrySet()) {
             if (e.getValue().equals(cls)) {

--- a/test/org/freedesktop/gstreamer/GstTypesTest.java
+++ b/test/org/freedesktop/gstreamer/GstTypesTest.java
@@ -1,0 +1,73 @@
+/* 
+ * Copyright (c) 2016 Christophe Lafolet
+ * 
+ * This file is part of gstreamer-java.
+ *
+ * gstreamer-java is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * gstreamer-java is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with gstreamer-java.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.freedesktop.gstreamer;
+
+import static org.junit.Assert.assertEquals;
+
+import org.freedesktop.gstreamer.lowlevel.GType;
+import org.freedesktop.gstreamer.lowlevel.GstTypes;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class GstTypesTest {
+
+    public GstTypesTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        Gst.init("GstTypesTest", new String[] {});
+    }
+    
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        Gst.deinit();
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test 
+    public void registeredClassTest() {
+    	// check a registered class
+    	GType elementType = GType.valueOf(Element.GTYPE_NAME);
+    	assertEquals(Element.class, GstTypes.classFor(elementType));
+    	assertEquals(elementType, GstTypes.typeFor(Element.class));
+    }
+
+    @Test 
+    public void unregisteredClassTest() {
+    	GType elementType = GType.valueOf(Element.GTYPE_NAME);
+    	// check a unregistered class which derived from Element 
+    	Element anElement = ElementFactory.make("avidemux", "avidemux");
+    	assertEquals(Element.class, GstTypes.classFor(anElement.getType()));
+    	
+    	// verify GType has not changed for Element.class
+    	assertEquals(elementType, GstTypes.typeFor(Element.class));
+    }
+}
+


### PR DESCRIPTION
The current implementation of GstTypes.typeFor() is very basic : it search the first GType associated with the input class, but it do not verify if it's a derived class or not. 