### PR TITLE
Set minimal source compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.test.jvmargs></maven.test.jvmargs>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Hi, this is simple change to make project green in Eclipse after import is done. I noticed that immediately after POM is imported the project turns red because Eclipse assumes 1.5 source compatibility (not sure why). This change is to fix this. With this change, immediately after POM is imported, the source compatibility will be set to 1.6 which is a minimal Java version for this project.