### PR TITLE
Add support for reading GValueArray backed fields from Structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 .project
 .settings
 
+/nbproject/

--- a/src/org/freedesktop/gstreamer/Gst.java
+++ b/src/org/freedesktop/gstreamer/Gst.java
@@ -1,5 +1,5 @@
 /* 
- * Copyright (c) 2015 Neil C Smith
+ * Copyright (c) 2017 Neil C Smith
  * Copyright (c) 2007 Wayne Meissner
  * 
  * This file is part of gstreamer-java.
@@ -49,11 +49,7 @@ import org.freedesktop.gstreamer.glib.GInetAddress;
 import org.freedesktop.gstreamer.glib.GSocketAddress;
 import org.freedesktop.gstreamer.glib.MainContextExecutorService;
 import org.freedesktop.gstreamer.lowlevel.GMainContext;
-import org.freedesktop.gstreamer.lowlevel.GValueAPI.GValue;
-import org.freedesktop.gstreamer.lowlevel.GValueAPI.GValueArray;
 import org.freedesktop.gstreamer.lowlevel.GstAPI.GErrorStruct;
-import org.freedesktop.gstreamer.lowlevel.GstControlSourceAPI.TimedValue;
-import org.freedesktop.gstreamer.lowlevel.GstControlSourceAPI.ValueArray;
 import org.freedesktop.gstreamer.lowlevel.GstTypes;
 import org.freedesktop.gstreamer.lowlevel.NativeObject;
 
@@ -61,6 +57,7 @@ import com.sun.jna.Memory;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
+import java.util.Arrays;
 
 /**
  * Media library supporting arbitrary formats and filter graphs.
@@ -439,55 +436,51 @@ public final class Gst {
 
     @SuppressWarnings("unchecked")
     private static synchronized void loadAllClasses() {
-        for(Class<?> cls : nativeClasses)
-            registerClass((Class<? extends NativeObject>)cls);
+        for(Class<? extends NativeObject> cls : nativeClasses) {
+            registerClass(cls);
+        }
     }
     // to generate the list we use:
     // egrep -rl "GST_NAME|GTYPE_NAME" src 2>/dev/null | egrep -v ".svn|Gst.java" | sort
     // even though the best would be all subclasses of NativeObject
     @SuppressWarnings("rawtypes")
-	private static Class[] nativeClasses = {
-		GDate.class,
-		GInetAddress.class,
-		GSocket.class,
-		GSocketAddress.class,
-		GInetSocketAddress.class,
-		GValue.class,
-		GValueArray.class,
-        TagList.class,
-		TimedValue.class,
-		ValueArray.class,
-		ValueList.class,
-		// ----------- Base -------------
-		Buffer.class,
-		BufferPool.class,
-		Bus.class,
-		Caps.class,
-		Clock.class,
-		DateTime.class,
-		Element.class,
-		ElementFactory.class,
-		Event.class,
-		GhostPad.class,
-		Message.class,
-		Pad.class,
-		PadTemplate.class,
-		Plugin.class,
-		PluginFeature.class,
-		Query.class,
-		Range.class,
-		Registry.class,
-        Sample.class,
-		// ----------- Elements -------------
-		AppSink.class,
-		AppSrc.class,
-		BaseSrc.class,
-		BaseSink.class,
-		BaseTransform.class,
-		Bin.class,
-		DecodeBin.class,
-		Pipeline.class,
-		PlayBin.class,
-		URIDecodeBin.class
-	};
+    private static List<Class<? extends NativeObject>> nativeClasses
+            = Arrays.<Class<? extends NativeObject>>asList(
+                    GDate.class,
+                    GInetAddress.class,
+                    GSocket.class,
+                    GSocketAddress.class,
+                    GInetSocketAddress.class,
+                    TagList.class,
+                    // ----------- Base -------------
+                    Buffer.class,
+                    BufferPool.class,
+                    Bus.class,
+                    Caps.class,
+                    Clock.class,
+                    DateTime.class,
+                    Element.class,
+                    ElementFactory.class,
+                    Event.class,
+                    GhostPad.class,
+                    Message.class,
+                    Pad.class,
+                    PadTemplate.class,
+                    Plugin.class,
+                    PluginFeature.class,
+                    Query.class,
+                    Registry.class,
+                    Sample.class,
+                    // ----------- Elements -------------
+                    AppSink.class,
+                    AppSrc.class,
+                    BaseSrc.class,
+                    BaseSink.class,
+                    BaseTransform.class,
+                    Bin.class,
+                    DecodeBin.class,
+                    Pipeline.class,
+                    PlayBin.class,
+                    URIDecodeBin.class
+            );
 }

--- a/src/org/freedesktop/gstreamer/Structure.java
+++ b/src/org/freedesktop/gstreamer/Structure.java
@@ -214,6 +214,29 @@ public class Structure extends NativeObject {
      * values are of G_TYPE_INT. Else if the field is of G_TYPE_INT a single value
      * array will be returned.
      * <p>
+     * This method will create a new array each time. If you are repeatedly calling
+     * this method consider using {@link #getIntegers(java.lang.String, int[])}.
+     * <p>
+     * Throws {@link InvalidFieldException} if the field does not exist, or the
+     * field values contained are not of type G_TYPE_INT.
+     * <p>
+     * This method only currently supports lists of values inside a GValueArray - 
+     * other native list types will be supported in future.
+     * 
+     * @param fieldName name of field
+     * @return List of values from the named field
+     */
+    public int[] getIntegers(String fieldName) {
+        return getIntegers(fieldName, null);
+    }
+    
+    /**
+     * Extract the values of the named field as an array of integers.
+     * If the native GType of the field is a GValueArray then this
+     * method will return an array of the contained values, assuming all contained
+     * values are of G_TYPE_INT. Else if the field is of G_TYPE_INT a single value
+     * array will be returned.
+     * <p>
      * An array may be passed into this method to contain the result. A new array
      * will be created if the array is null or not of the correct length.
      * <p>
@@ -274,6 +297,29 @@ public class Structure extends NativeObject {
             throw new InvalidFieldException("double", fieldName);
         }
         return val[0];
+    }
+    
+    /**
+     * Extract the values of the named field as an array of doubles.
+     * If the native GType of the field is a GValueArray then this
+     * method will return an array of the contained values, assuming all contained
+     * values are of G_TYPE_DOUBLE. Else if the field is of G_TYPE_DOUBLE a single value
+     * array will be returned.
+     * <p>
+     * This method will create a new array each time. If you are repeatedly calling
+     * this method consider using {@link #getDoubles(java.lang.String, double[])}.
+     * <p>
+     * Throws {@link InvalidFieldException} if the field does not exist, or the
+     * field values contained are not of type G_TYPE_DOUBLE.
+     * <p>
+     * This method only currently supports lists of values inside a GValueArray - 
+     * other native list types will be supported in future.
+     * 
+     * @param fieldName name of field
+     * @return List of values from the named field
+     */
+    public double[] getDoubles(String fieldName) {
+        return getDoubles(fieldName, null);
     }
     
     /**

--- a/src/org/freedesktop/gstreamer/ValueList.java
+++ b/src/org/freedesktop/gstreamer/ValueList.java
@@ -21,6 +21,7 @@ package org.freedesktop.gstreamer;
 import org.freedesktop.gstreamer.lowlevel.GValueAPI;
 import org.freedesktop.gstreamer.lowlevel.GstValueAPI;
 
+@Deprecated
 public class ValueList {
 	public static final String GTYPE_NAME = "GstValueList";
 

--- a/src/org/freedesktop/gstreamer/lowlevel/GValueAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GValueAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Neil C Smith
+ * Copyright (c) 2017 Neil C Smith
  * Copyright (c) 2009 Levente Farkas
  * Copyright (c) 2008 Andres Colubri
  * Copyright (c) 2008 Wayne Meissner
@@ -162,6 +162,8 @@ public interface GValueAPI extends Library {
             } else if (g_type.equals(GType.STRING)) { return toJavaString();
 //            } else if (g_type.equals(GType.OBJECT)) { return toObject();
             } else if (g_type.equals(GType.POINTER)) { return toPointer();
+            } else if (g_type.equals(GValueArray.GTYPE)) {
+                return new GValueArray(GVALUE_API.g_value_get_boxed(this));
             } else if (g_type.getParentType().equals(GType.BOXED)) {
                 Class<? extends NativeObject> cls = GstTypes.classFor(g_type);
                 if (cls != null) {
@@ -235,6 +237,7 @@ public interface GValueAPI extends Library {
     
     public static final class GValueArray extends com.sun.jna.Structure {
     	public static final String GTYPE_NAME = "GValueArray";
+        static final GType GTYPE = GType.valueOf(GTYPE_NAME);
 
     	public volatile int n_values;
         public volatile Pointer values;

--- a/test/org/freedesktop/gstreamer/StructureTest.java
+++ b/test/org/freedesktop/gstreamer/StructureTest.java
@@ -1,9 +1,10 @@
 package org.freedesktop.gstreamer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import java.util.List;
+import static org.junit.Assert.*;
 
 import org.freedesktop.gstreamer.lowlevel.GType;
+import org.freedesktop.gstreamer.lowlevel.GValueAPI;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -49,8 +50,28 @@ public class StructureTest {
 		assertEquals(true, structure.getValue("bool"));
 		
 	}
-
-
+    
+    @Test
+    public void testGetValues() {
+        GValueAPI.GValueArray ar = new GValueAPI.GValueArray(2);
+        ar.append(new GValueAPI.GValue(GType.DOUBLE, 7.5));
+        ar.append(new GValueAPI.GValue(GType.DOUBLE, 14.3));
+        structure.setValue("valuearray", GType.valueOf(GValueAPI.GValueArray.GTYPE_NAME), ar);
+        List<Double> doubles = structure.getValues(Double.class, "valuearray");
+        assertEquals(7.5, doubles.get(0), 0.001);
+        assertEquals(14.3, doubles.get(1), 0.001);
+        try {
+            List<String> strings = structure.getValues(String.class, "valuearray");
+            fail("Trying to extract the wrong type from GValueArray not throwing exception");
+        } catch (Structure.InvalidFieldException ex) {
+        }
+        try {
+            List<Double> strings = structure.getValues(Double.class, "non_existent");
+            fail("Trying to extract a non-existent GValueArray field");
+        } catch (Structure.InvalidFieldException ex) {
+        }
+    }
+    
 	@Test
 	public void testGetInteger() {
 		structure.setInteger("int", 9);		
@@ -59,7 +80,30 @@ public class StructureTest {
 		structure.setInteger("int", -9);		
 		assertEquals(-9, structure.getInteger("int"));				
 	}
-
+    
+    @Test
+    public void testGetIntegers() {
+        GValueAPI.GValueArray ar = new GValueAPI.GValueArray(2);
+        ar.append(new GValueAPI.GValue(GType.INT, 32));
+        ar.append(new GValueAPI.GValue(GType.INT, -49));
+        structure.setValue("integers", GType.valueOf(GValueAPI.GValueArray.GTYPE_NAME), ar);
+        int[] in = new int[2];
+        int[] ints = structure.getIntegers("integers", in);
+        assertTrue(in == ints);
+        assertEquals(32, ints[0]);
+        assertEquals(-49, ints[1]);
+        
+        in = new int[1];
+        ints = structure.getIntegers("integers", in);
+        assertFalse(in == ints);
+        assertEquals(32, ints[0]);
+        assertEquals(-49, ints[1]);
+        
+        structure.setInteger("single_integer", 18);
+        int[] single = structure.getIntegers("single_integer", in);
+        assertTrue(in == single);
+        assertEquals(18, single[0]);
+    }
 
 	@Test
 	public void testGetDouble() {
@@ -69,6 +113,30 @@ public class StructureTest {
 		structure.setDouble("double", -9.0);		
 		assertEquals(-9.0, structure.getDouble("double"), 0);				
 	}
+    
+    @Test
+    public void testGetDoubles() {
+        GValueAPI.GValueArray ar = new GValueAPI.GValueArray(2);
+        ar.append(new GValueAPI.GValue(GType.DOUBLE, 3.25));
+        ar.append(new GValueAPI.GValue(GType.DOUBLE, 79.6));
+        structure.setValue("doubles", GType.valueOf(GValueAPI.GValueArray.GTYPE_NAME), ar);
+        double[] in = new double[2];
+        double[] doubles = structure.getDoubles("doubles", in);
+        assertTrue(in == doubles);
+        assertEquals(3.25, doubles[0], 0.001);
+        assertEquals(79.6, doubles[1], 0.001);
+        
+        in = new double[1];
+        doubles = structure.getDoubles("doubles", in);
+        assertFalse(in == doubles);
+        assertEquals(3.25, doubles[0], 0.001);
+        assertEquals(79.6, doubles[1], 0.001);
+        
+        structure.setDouble("single_double", 18.2);
+        double[] single = structure.getDoubles("single_double", in);
+        assertTrue(in == single);
+        assertEquals(18.2, single[0], 0.001);
+    }
 
 	@Test
 	public void testFraction() {


### PR DESCRIPTION
Add support for reading GValueArray backed fields from Structure, deprecate `ValueList` and fix issues with non-NativeObject classes being registered in `Gst`