### PR TITLE
include new gstreamer message types; Pad.link() return result becomes an exception

### DIFF
--- a/src/org/freedesktop/gstreamer/MessageType.java
+++ b/src/org/freedesktop/gstreamer/MessageType.java
@@ -209,6 +209,22 @@ public enum MessageType implements IntegerEnum {
      */
     DEVICE_REMOVED(EXTENDED.intValue() + 2),
     /**
+     * Message indicating a {@link GObject} property has changed (Since 1.10)
+     */
+    PROPERTY_NOTIFY(EXTENDED.intValue() + 3),
+    /**
+     * Message indicating a new {@link GstStreamCollection} is available (Since 1.10)
+     */
+    STREAM_COLLECTION(EXTENDED.intValue()+4),
+    /**
+     * Message indicating the active selection of {@link GstStreams} has changed (Since 1.10)
+     */
+    STREAMS_SELECTED(EXTENDED.intValue() + 5),
+    /**
+     * Message indicating to request the application to try to play the given URL(s). Useful if for example a HTTP 302/303 response is received with a non-HTTP URL inside. (Since 1.10)
+     */
+    REDIRECT(EXTENDED.intValue() + 6),
+    /**
      * mask for all of the above messages.
      */
     ANY(~0);

--- a/src/org/freedesktop/gstreamer/Pad.java
+++ b/src/org/freedesktop/gstreamer/Pad.java
@@ -203,16 +203,26 @@ public class Pad extends GstObject {
     }
     
     /**
-     * Links this pad and a sink pad.
+     * Links this source pad and a sink pad.
      *
      * MT Safe.
-     * @param pad the sink Pad to link.
-     * @return A result code indicating if the connection worked or what went wrong.
+     * @param sink the sink Pad to link.
+     * @throws
      */
-    public PadLinkReturn link(Pad pad) {
-        return GSTPAD_API.gst_pad_link(this, pad);
+    public void link(Pad sink)
+        throws PadLinkException
+    {
+        PadLinkReturn result = link_(sink);
+        if (result!=PadLinkReturn.OK) {
+            throw new PadLinkException(result);
+        }
     }
-    
+
+    public PadLinkReturn link_(Pad sink)
+    {
+        return GSTPAD_API.gst_pad_link(this, sink);
+    }
+
     /**
      *
      * Unlinks the source pad from the sink pad. 

--- a/src/org/freedesktop/gstreamer/Pad.java
+++ b/src/org/freedesktop/gstreamer/Pad.java
@@ -207,20 +207,13 @@ public class Pad extends GstObject {
      *
      * MT Safe.
      * @param sink the sink Pad to link.
-     * @throws
+     * @throws PadLinkException if pads cannot be linked.
      */
-    public void link(Pad sink)
-        throws PadLinkException
-    {
-        PadLinkReturn result = link_(sink);
-        if (result!=PadLinkReturn.OK) {
+    public void link(Pad sink) throws PadLinkException {
+        PadLinkReturn result = GSTPAD_API.gst_pad_link(this, sink);
+        if (result != PadLinkReturn.OK) {
             throw new PadLinkException(result);
         }
-    }
-
-    public PadLinkReturn link_(Pad sink)
-    {
-        return GSTPAD_API.gst_pad_link(this, sink);
     }
 
     /**

--- a/src/org/freedesktop/gstreamer/PadLinkException.java
+++ b/src/org/freedesktop/gstreamer/PadLinkException.java
@@ -1,7 +1,10 @@
 package org.freedesktop.gstreamer;
 
+/**
+ * The exception you can throw when a pad link operation returns a non-OK result
+ */
 public class PadLinkException
-    extends Exception
+    extends GstException
 {
     public final PadLinkReturn linkResult;
 

--- a/src/org/freedesktop/gstreamer/PadLinkException.java
+++ b/src/org/freedesktop/gstreamer/PadLinkException.java
@@ -1,0 +1,18 @@
+package org.freedesktop.gstreamer;
+
+public class PadLinkException
+    extends Exception
+{
+    public final PadLinkReturn linkResult;
+
+    public PadLinkException(PadLinkReturn result)
+    {
+        this("failed to link pads ("+result+")", result);
+    }
+
+    public PadLinkException(String message, PadLinkReturn result)
+    {
+        super(message);
+        linkResult = result;
+    }
+}

--- a/src/org/freedesktop/gstreamer/PadLinkException.java
+++ b/src/org/freedesktop/gstreamer/PadLinkException.java
@@ -1,21 +1,27 @@
 package org.freedesktop.gstreamer;
 
 /**
- * The exception you can throw when a pad link operation returns a non-OK result
+ * The exception thrown when a pad link operation returns a non-OK result
  */
-public class PadLinkException
-    extends GstException
-{
-    public final PadLinkReturn linkResult;
+public class PadLinkException extends GstException {
 
-    public PadLinkException(PadLinkReturn result)
-    {
-        this("failed to link pads ("+result+")", result);
+    private final PadLinkReturn linkResult;
+
+    PadLinkException(PadLinkReturn result) {
+        this("failed to link pads (" + result + ")", result);
     }
 
-    public PadLinkException(String message, PadLinkReturn result)
-    {
+    PadLinkException(String message, PadLinkReturn result) {
         super(message);
         linkResult = result;
     }
+
+    /**
+     * Get the PadLinkReturn result that caused this exception.
+     * @return PadLinkReturn
+     */
+    public PadLinkReturn getLinkResult() {
+        return linkResult;
+    }
+    
 }

--- a/test/org/freedesktop/gstreamer/BinTest.java
+++ b/test/org/freedesktop/gstreamer/BinTest.java
@@ -179,7 +179,7 @@ public class BinTest {
             fail("Should not be able to link pads in different hierarchy");
         } catch (PadLinkException e) {
             assertEquals("Should not be able to link pads in different hierarchy",
-                PadLinkReturn.WRONG_HIERARCHY, e.linkResult);
+                PadLinkReturn.WRONG_HIERARCHY, e.getLinkResult());
         }
 
         /* adding other element to bin as well */

--- a/test/org/freedesktop/gstreamer/BinTest.java
+++ b/test/org/freedesktop/gstreamer/BinTest.java
@@ -23,8 +23,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import java.lang.ref.WeakReference;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -143,7 +143,9 @@ public class BinTest {
         assertEquals("Callback not called", 2, removed.get());
     }
     @Test 
-    public void addLinked() {
+    public void addLinked()
+        throws PadLinkException
+    {
         /* adding an element with linked pads to a bin unlinks the pads */
         Pipeline pipeline = new Pipeline((String) null);
         assertNotNull("Could not create pipeline", pipeline);
@@ -158,7 +160,7 @@ public class BinTest {
         Pad sinkpad = sink.getStaticPad("sink");
         assertNotNull("Could not get sink pad", sinkpad);
         
-        assertEquals("Could not link src and sink pads", PadLinkReturn.OK, srcpad.link(sinkpad));
+        srcpad.link(sinkpad);
 
         /* pads are linked now */
         assertTrue("srcpad not linked", srcpad.isLinked());
@@ -172,14 +174,19 @@ public class BinTest {
         assertFalse("sinkpad is still linked after being added to bin", sinkpad.isLinked());
         
         /* cannot link pads in wrong hierarchy */
-        assertEquals("Should not be able to link pads in different hierarchy", 
-                PadLinkReturn.WRONG_HIERARCHY, srcpad.link(sinkpad));
+        try {
+            srcpad.link(sinkpad);
+            fail("Should not be able to link pads in different hierarchy");
+        } catch (PadLinkException e) {
+            assertEquals("Should not be able to link pads in different hierarchy",
+                PadLinkReturn.WRONG_HIERARCHY, e.linkResult);
+        }
 
         /* adding other element to bin as well */
         pipeline.add(sink);
 
         /* now we can link again */
-        assertEquals("Could not link src and sink pads when in same bin", PadLinkReturn.OK, srcpad.link(sinkpad));
+        srcpad.link(sinkpad);
 
         /* check if pads really are linked */
         assertTrue("srcpad not linked", srcpad.isLinked());

--- a/test/org/freedesktop/gstreamer/PadTest.java
+++ b/test/org/freedesktop/gstreamer/PadTest.java
@@ -81,12 +81,14 @@ public class PadTest {
         assertTrue("Sink pad not garbage collected", GCTracker.waitGC(sinkRef));
     }
     @Test
-    public void padLink() throws Exception {
+    public void padLink()
+        throws Exception
+    {
         Element src = ElementFactory.make("fakesrc", "src");
         Element sink = ElementFactory.make("fakesink", "src");
         Pad srcPad = src.getStaticPad("src");
         Pad sinkPad = sink.getStaticPad("sink");
-        assertEquals("Could not link pads", PadLinkReturn.OK, srcPad.link(sinkPad));
+        srcPad.link(sinkPad);
     }
 
     @Ignore("This seems to fail because gst1.0 doesn't actually send the event because pads " +

--- a/test/org/freedesktop/gstreamer/PluginTest.java
+++ b/test/org/freedesktop/gstreamer/PluginTest.java
@@ -76,7 +76,9 @@ public class PluginTest {
 
     @Test
     public void testGetPackage() {
-        assertTrue(playbackPlugin.getPackage().contains("GStreamer Base"));
+        String pkg = playbackPlugin.getPackage();
+        assertTrue(pkg.contains("GStreamer Base")
+        || pkg.contains("Gentoo GStreamer ebuild"));
     }
 
     @Test


### PR DESCRIPTION
Recent versions of gstreamer have some new message types that were missing from MessageTypes.java.  These almost certainly should be included.

Pad.link() returns a result which is very easy for new programmers to ignore.  By converting it to an exception the using code becomes more compact, allowing new programmers to detect mistakes much earlier (I'm looking at you WRONG_HIERARCHY) and allowing veteran programmers to concentrate their error handling in a catch clause wherever is architecturally correct.  This change can break existing code (although deriving from RuntimeException instead of Exception might cover most of those cases, although I'm not entirely sure I am ready to recommend that).