### PR TITLE
Remove deprecated/discouraged usages of JNA constructs

### DIFF
--- a/src/org/freedesktop/gstreamer/GObject.java
+++ b/src/org/freedesktop/gstreamer/GObject.java
@@ -356,7 +356,7 @@ public abstract class GObject extends RefCountedObject {
 		int offset = 0;
 		for (int i = 0; i < len.getValue(); i++) {
 			props[i] = new GObjectAPI.GParamSpec(ptrs.getPointer(offset));
-			offset += Pointer.SIZE;
+			offset += Native.POINTER_SIZE;
 		}
 		return props;
 	}

--- a/src/org/freedesktop/gstreamer/Gst.java
+++ b/src/org/freedesktop/gstreamer/Gst.java
@@ -91,12 +91,12 @@ public final class Gst {
             // Insert the program name as argv[0]
             //
             Memory arg = new Memory(progname.getBytes().length + 4);
-            arg.setString(0, progname, false);
+            arg.setString(0, progname);
             argsCopy[0] = arg;
             
             for (int i = 0; i < args.length; i++) {
                 arg = new Memory(args[i].getBytes().length + 1);
-                arg.setString(0, args[i], false);
+                arg.setString(0, args[i]);
                 argsCopy[i + 1] = arg;
             }
             argvMemory.write(0, argsCopy, 0, argsCopy.length);
@@ -112,7 +112,7 @@ public final class Gst {
             for (int i = 1; i < argcRef.getValue(); i++) {
                 Pointer arg = argv.getPointer(i * Native.POINTER_SIZE);
                 if (arg != null) {
-                    args.add(arg.getString(0, false));
+                    args.add(arg.getString(0));
                 }
             }
             return args.toArray(new String[args.size()]);

--- a/src/org/freedesktop/gstreamer/Gst.java
+++ b/src/org/freedesktop/gstreamer/Gst.java
@@ -54,6 +54,7 @@ import org.freedesktop.gstreamer.lowlevel.GstTypes;
 import org.freedesktop.gstreamer.lowlevel.NativeObject;
 
 import com.sun.jna.Memory;
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
@@ -84,7 +85,7 @@ public final class Gst {
             // Allocate some native memory to pass the args down to the native layer
             //
             argsCopy = new Memory[args.length + 2];
-            argvMemory = new Memory(argsCopy.length * Pointer.SIZE);
+            argvMemory = new Memory(argsCopy.length * Native.POINTER_SIZE);
             
             //
             // Insert the program name as argv[0]
@@ -109,7 +110,7 @@ public final class Gst {
             List<String> args = new ArrayList<String>();
             Pointer argv = argvRef.getValue();
             for (int i = 1; i < argcRef.getValue(); i++) {
-                Pointer arg = argv.getPointer(i * Pointer.SIZE);
+                Pointer arg = argv.getPointer(i * Native.POINTER_SIZE);
                 if (arg != null) {
                     args.add(arg.getString(0, false));
                 }

--- a/src/org/freedesktop/gstreamer/TagList.java
+++ b/src/org/freedesktop/gstreamer/TagList.java
@@ -265,7 +265,7 @@ public class TagList extends MiniObject {
                     if (value[0] == null) {
                         return null;
                     }
-                    String ret = value[0].getString(0, false);
+                    String ret = value[0].getString(0);
                     GLIB_API.g_free(value[0]);
                     return ret;
                 }

--- a/src/org/freedesktop/gstreamer/lowlevel/BaseSinkAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/BaseSinkAPI.java
@@ -43,6 +43,7 @@ import org.freedesktop.gstreamer.query.AllocationQuery;
 
 import com.sun.jna.Callback;
 import com.sun.jna.Library;
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 
 /**
@@ -220,7 +221,7 @@ public interface BaseSinkAPI extends Library {
         public RenderList render_list;
 
         /*< private >*/
-        public volatile byte[] _gst_reserved = new byte[Pointer.SIZE * BaseSinkAPI.GST_PADDING_LARGE];
+        public volatile byte[] _gst_reserved = new byte[Native.POINTER_SIZE * BaseSinkAPI.GST_PADDING_LARGE];
 
         @Override
         protected List<String> getFieldOrder() {

--- a/src/org/freedesktop/gstreamer/lowlevel/BaseSrcAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/BaseSrcAPI.java
@@ -34,6 +34,7 @@ import org.freedesktop.gstreamer.lowlevel.GstElementAPI.GstElementStruct;
 
 import com.sun.jna.Callback;
 import com.sun.jna.Library;
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Union;
 import com.sun.jna.ptr.LongByReference;
@@ -229,7 +230,7 @@ public interface BaseSrcAPI extends Library {
         public PrepareSeek prepare_seek_segment;
         
         /*< private >*/
-        public volatile byte[] _gst_reserved = new byte[Pointer.SIZE * (GST_PADDING_LARGE - 6)];
+        public volatile byte[] _gst_reserved = new byte[Native.POINTER_SIZE * (GST_PADDING_LARGE - 6)];
     
         @Override
         protected List<String> getFieldOrder() {

--- a/src/org/freedesktop/gstreamer/lowlevel/BaseTransformAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/BaseTransformAPI.java
@@ -33,6 +33,7 @@ import org.freedesktop.gstreamer.lowlevel.GstElementAPI.GstElementStruct;
 
 import com.sun.jna.Callback;
 import com.sun.jna.Library;
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 import java.util.Arrays;
@@ -175,7 +176,7 @@ public interface BaseTransformAPI extends Library {
         public AcceptCaps accept_caps;
 
         /*< private >*/
-        public volatile byte[] _gst_reserved = new byte[Pointer.SIZE * (GST_PADDING_LARGE - 3)];
+        public volatile byte[] _gst_reserved = new byte[Native.POINTER_SIZE * (GST_PADDING_LARGE - 3)];
 
         @Override
         protected List<String> getFieldOrder() {

--- a/src/org/freedesktop/gstreamer/lowlevel/GObjectAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GObjectAPI.java
@@ -31,6 +31,7 @@ import org.freedesktop.gstreamer.lowlevel.GValueAPI.GValue;
 
 import com.sun.jna.Callback;
 import com.sun.jna.Library;
+import com.sun.jna.Native;
 import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure.ByReference;
@@ -178,7 +179,7 @@ public interface GObjectAPI extends Library {
         public Finalize finalize;
         public volatile Pointer dispatch_properties_changed;
         public Notify notify;
-        public volatile byte[] p_dummy = new byte[8 * Pointer.SIZE];
+        public volatile byte[] p_dummy = new byte[8 * Native.POINTER_SIZE];
         
         public static interface Constructor extends Callback {
             public Pointer callback(GType type, int n_construct_properties, 

--- a/src/org/freedesktop/gstreamer/lowlevel/GTypeMapper.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GTypeMapper.java
@@ -37,6 +37,7 @@ import com.sun.jna.FromNativeContext;
 import com.sun.jna.FromNativeConverter;
 import com.sun.jna.MethodParameterContext;
 import com.sun.jna.MethodResultContext;
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.StructureReadContext;
 import com.sun.jna.ToNativeContext;
@@ -230,7 +231,7 @@ public class GTypeMapper extends com.sun.jna.DefaultTypeMapper {
         }
 
         public Class<?> nativeType() {
-            return Pointer.SIZE == 8 ? Long.class : Integer.class;
+            return Native.POINTER_SIZE == 8 ? Long.class : Integer.class;
         }
     };
     private TypeConverter querytypeConverter = new TypeConverter() {

--- a/src/org/freedesktop/gstreamer/lowlevel/GstAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GstAPI.java
@@ -23,6 +23,7 @@ import org.freedesktop.gstreamer.Format;
 import org.freedesktop.gstreamer.lowlevel.annotations.CallerOwnsReturn;
 
 import com.sun.jna.Library;
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
@@ -87,7 +88,7 @@ public interface GstAPI extends Library {
         public long duration;
 
         /*< private >*/
-        public volatile byte[] _gst_reserved = new byte[(Pointer.SIZE * GST_PADDING) - (Double.SIZE / 8)];
+        public volatile byte[] _gst_reserved = new byte[(Native.POINTER_SIZE * GST_PADDING) - (Double.SIZE / 8)];
 
         @Override
         protected List<String> getFieldOrder() {

--- a/src/org/freedesktop/gstreamer/lowlevel/GstPadTemplateAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GstPadTemplateAPI.java
@@ -19,6 +19,7 @@
 
 package org.freedesktop.gstreamer.lowlevel;
 
+import com.sun.jna.Native;
 import org.freedesktop.gstreamer.Caps;
 import org.freedesktop.gstreamer.Pad;
 import org.freedesktop.gstreamer.PadDirection;
@@ -29,8 +30,6 @@ import org.freedesktop.gstreamer.lowlevel.annotations.IncRef;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.PointerType;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * GstPadTemplate functions
@@ -69,11 +68,11 @@ public interface GstPadTemplateAPI extends com.sun.jna.Library {
         }
         
         public PadDirection getPadDirection() {
-            return PadDirection.values()[getPointer().getInt(Pointer.SIZE)];
+            return PadDirection.values()[getPointer().getInt(Native.POINTER_SIZE)];
         }
         
         public PadPresence getPadPresence() {
-            return PadPresence.values()[getPointer().getInt(Pointer.SIZE + 4)];
+            return PadPresence.values()[getPointer().getInt(Native.POINTER_SIZE + 4)];
         }
     }  
     

--- a/src/org/freedesktop/gstreamer/lowlevel/IntPtr.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/IntPtr.java
@@ -17,13 +17,13 @@
  */
 package org.freedesktop.gstreamer.lowlevel;
 
-import com.sun.jna.Pointer;
+import com.sun.jna.Native;
 
 @SuppressWarnings("serial")
 public class IntPtr extends Number {
     public final Number value;
     public IntPtr(int value) {
-        this.value = Pointer.SIZE == 8 ? new Long(value) : new Integer(value);
+        this.value = Native.POINTER_SIZE == 8 ? new Long(value) : new Integer(value);
     }
     
     public String toString() {        


### PR DESCRIPTION
This message on the gst-java mailinglist:

https://groups.google.com/forum/#!topic/gstreamer-java/hlyZ8yEo9gs

most probably resulted from using JNA 5.X-SNAPSHOT with the current gst-java codebase.

The upcoming JNA 5.X version will remove deprecated methods/elements and in addition
will not provide Pointer#SIZE anymore. Pointer#SIZE was part of class loading problems,
leading to deadlocks in the class loader and was removed without deprecation.

The changes are compatible with JNA 4.5.X and the replacements were present for a
long time (10 years + 5 years).

Unittests were run before and after the change and run cleanly.

While testing I noticed, that the version range includes 5.0.0-SNAPSHOT. I have not
looked to deeply into this, but the pom version range most probably should be:

```xml
    <dependency>
      <groupId>net.java.dev.jna</groupId>
      <artifactId>jna</artifactId>
      <version>[4.4.0,5-SNAPHOT)</version>
    </dependency>
```

The `-SNAPSHOT` version is always considered smaller as its base version. Given
that I might be a minority, having JNA snapshots present.