### PR TITLE
Version API

### DIFF
--- a/src/org/freedesktop/gstreamer/Gst.java
+++ b/src/org/freedesktop/gstreamer/Gst.java
@@ -84,6 +84,7 @@ public final class Gst {
     private static GMainContext mainContext;
     private static boolean useDefaultContext = false;
     private static List<Runnable> shutdownTasks = Collections.synchronizedList(new ArrayList<Runnable>());
+    // set minorVersion to a value guaranteed to be >= anything else unless set in init()
     private static int minorVersion = Integer.MAX_VALUE;
     
     public static class NativeArgs {
@@ -493,8 +494,9 @@ public final class Gst {
                 requestedVersion = new Version(1, 8);
             }
             if (!availableVersion.checkSatisfies(requestedVersion)) {
-                throw new GstException("The requested version of GStreamer is not available\n"
-                        + "Requested : " + requestedVersion + "\nAvailable : " + availableVersion);
+                throw new GstException(String.format(
+                        "The requested version of GStreamer is not available\nRequested : %s\nAvailable : %s\n",
+                        requestedVersion, availableVersion));
             }
         }
         

--- a/src/org/freedesktop/gstreamer/Gst.java
+++ b/src/org/freedesktop/gstreamer/Gst.java
@@ -60,6 +60,9 @@ import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
 import java.util.logging.Level;
 import static org.freedesktop.gstreamer.lowlevel.GstParseAPI.GSTPARSE_API;
@@ -745,4 +748,18 @@ public final class Gst {
                     URIDecodeBin.class,
                     WebRTCBin.class
             );
+    
+    /**
+     * Annotation on classes, methods or fields to show the required GStreamer
+     * version. This should particularly be used where the version required is higher
+     * than the current baseline supported version (GStreamer 1.8)
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    public static @interface Since {
+        public int major() default 1;
+        public int minor();
+    }
+    
+    
 }

--- a/src/org/freedesktop/gstreamer/Version.java
+++ b/src/org/freedesktop/gstreamer/Version.java
@@ -1,5 +1,6 @@
 /* 
- * Copyright (c) 2007, 2008 Wayne Meissner
+ * Copyright (c) 2019 Neil C Smith
+ * Copyright (c) 2008 Wayne Meissner
  * 
  * This file is part of gstreamer-java.
  *
@@ -13,16 +14,23 @@
  * version 3 for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * version 3 along with this work.  If not, see <http://www.gnu.org/licenses/>.
+ * version 3 aint with this work.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.freedesktop.gstreamer;
 
 /**
- * Describes the version of gstreamer currently in use.
+ * Describes a GStreamer version.
  */
 public class Version {
-    public Version(long major, long minor, long micro, long nano) {
+    
+    private final int major, minor, micro, nano;
+    
+    public Version(int major, int minor) {
+        this(major, minor, 0, 0);
+    }
+    
+    public Version(int major, int minor, int micro, int nano) {
         this.major = major;
         this.minor = minor;
         this.micro = micro;
@@ -42,35 +50,46 @@ public class Version {
     }
     
     /**
-     * Gets the major version of GStreamer at compile time.
+     * Gets the major version of GStreamer.
      * @return the major version.
      */
-    public long getMajor() {
+    public int getMajor() {
         return major;
     }
     
     /**
-     * Gets the minor version of GStreamer at compile time.
+     * Gets the minor version of GStreamer.
      * @return the minor version.
      */
-    public long getMinor() {
+    public int getMinor() {
         return minor;
     }
     
     /**
-     * Gets the micro version of GStreamer at compile time.
+     * Gets the micro version of GStreamer.
      * @return the micro version.
      */
-    public long getMicro() {
+    public int getMicro() {
         return micro;
     }
     
     /**
-     * Gets the nano version of GStreamer at compile time.
+     * Gets the nano version of GStreamer.
      * @return the nano version.
      */
-    public long getNano() {
+    public int getNano() {
         return nano;
     }
-    private final long major, minor, micro, nano;
+    
+    /**
+     * Check whether this version is equal to or greater than the passed in 
+     * version. Roughly comparable to GST_CHECK_VERSION
+     * @param required version to check against
+     * @return true if this version satisfies the required version
+     */
+    public boolean checkSatisfies(Version required) {
+        return (major == required.major && minor > required.minor) ||
+                (major == required.major && minor == required.minor && micro >= required.micro);
+    }
+    
 }

--- a/src/org/freedesktop/gstreamer/Version.java
+++ b/src/org/freedesktop/gstreamer/Version.java
@@ -14,7 +14,7 @@
  * version 3 for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * version 3 aint with this work.  If not, see <http://www.gnu.org/licenses/>.
+ * version 3 along with this work.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.freedesktop.gstreamer;

--- a/test/org/freedesktop/gstreamer/InitTest.java
+++ b/test/org/freedesktop/gstreamer/InitTest.java
@@ -1,4 +1,5 @@
 /* 
+ * Copyright (c) 2019 Neil C Smith
  * Copyright (c) 2007 Wayne Meissner
  * 
  * This file is part of gstreamer-java.
@@ -37,8 +38,22 @@ public class InitTest {
     }
     @Test
     public void testInit() {
-        String[] args = Gst.init("InitTest", new String[] { "--gst-plugin-spew" });
+        Version available = Gst.getVersion();
+        Version notAvailable = new Version(available.getMajor(), available.getMinor() + 2);
+        try {
+            Gst.init(notAvailable);
+            assertTrue("Version check exception not thrown!", false);
+        } catch (GstException ex) {
+            System.out.println("Expected init failure");
+            System.out.println(ex);
+        }
+        String[] args = Gst.init(available, "InitTest", "--gst-plugin-spew");
         assertTrue(args.length == 0);
+        
+        assertTrue(Gst.testVersion(available.getMajor(), available.getMinor()));
+        assertTrue(Gst.testVersion(available.getMajor(), available.getMinor() - 2));
+        assertTrue(!Gst.testVersion(notAvailable.getMajor(), notAvailable.getMinor()));
+        
         Gst.deinit();
     }
     @BeforeClass


### PR DESCRIPTION
Provide a Version API as discussed in #77 

- add variants of init() that require a Version to be passed in
- deprecate old versions of init() - can use `Gst.init(Gst.getVersion());` to get old (not recommended) behaviour
- test actual version satisfies requested version and fail if not
- add `Gst.checkVersion(..)` and `Gst.testVersion(..)` to test _requested_ version satisfies dependencies, throwing exception or returning boolean respectively
- add `@Gst.Since` annotation for classes, methods and fields that require above baseline (1.8) version of GStreamer - shows in Javadoc and runtime introspectable.
