### PR TITLE
Allow property data to be null in GObject::set

### DIFF
--- a/src/org/freedesktop/gstreamer/glib/GObject.java
+++ b/src/org/freedesktop/gstreamer/glib/GObject.java
@@ -308,7 +308,7 @@ public abstract class GObject extends RefCountedObject {
     public void set(String property, Object data) {
         LOG.entering("GObject", "set", new Object[]{property, data});
         GObjectAPI.GParamSpec propertySpec = findProperty(property);
-        if (propertySpec == null || data == null) {
+        if (propertySpec == null /*|| data == null*/) {
             throw new IllegalArgumentException("Unknown property: " + property);
         }
         final GType propType = propertySpec.value_type;


### PR DESCRIPTION
Allow property data to be null in GObject::set - some conversions will throw NPE later if null is not allowed anyway.