### PR TITLE
Structure: Add Accessor for GstValueList Fields

### DIFF
--- a/src/org/freedesktop/gstreamer/Structure.java
+++ b/src/org/freedesktop/gstreamer/Structure.java
@@ -436,8 +436,8 @@ public class Structure extends NativeObject {
      * Throws {@link InvalidFieldException} if the field does not exist, or the
      * field values cannot be converted to type T.
      * <p>
-     * This method only currently supports lists of values inside a GValueArray
-     * - other native list types will be supported in future.
+     * This method currently supports lists of values inside a GValueArray or
+     * GstValueList.
      *
      * @param <T>
      * @param type type of values

--- a/src/org/freedesktop/gstreamer/Structure.java
+++ b/src/org/freedesktop/gstreamer/Structure.java
@@ -210,7 +210,22 @@ public class Structure extends NativeObject {
             }
         }
     }
-    
+
+    public <T> List<T> getValueList(String fieldName) {
+        GValue val = GSTSTRUCTURE_API.gst_structure_get_value(this, fieldName);
+        if(!val.g_type.equals(GSTVALUE_API.gst_value_list_get_type())) {
+            return null;
+        }
+
+        int size = GSTVALUE_API.gst_value_list_get_size(val);
+        ArrayList<T> values = new ArrayList<>(size);
+        for (int i = 0; i <size; i++) {
+            //noinspection unchecked
+            values.add((T) GSTVALUE_API.gst_value_list_get_value(val, i).getValue());
+        }
+        return values;
+    }
+
     /**
      * Get the number of fields in the {@link Structure}.
      *

--- a/src/org/freedesktop/gstreamer/Structure.java
+++ b/src/org/freedesktop/gstreamer/Structure.java
@@ -21,17 +21,18 @@ package org.freedesktop.gstreamer;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.PointerByReference;
+import org.freedesktop.gstreamer.glib.NativeObject;
+import org.freedesktop.gstreamer.glib.Natives;
+import org.freedesktop.gstreamer.lowlevel.GPointer;
+import org.freedesktop.gstreamer.lowlevel.GType;
+import org.freedesktop.gstreamer.lowlevel.GValueAPI;
+import org.freedesktop.gstreamer.lowlevel.GValueAPI.GValue;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.freedesktop.gstreamer.lowlevel.GType;
-import org.freedesktop.gstreamer.lowlevel.GValueAPI;
-import org.freedesktop.gstreamer.glib.NativeObject;
-import org.freedesktop.gstreamer.glib.Natives;
-import org.freedesktop.gstreamer.lowlevel.GPointer;
-import org.freedesktop.gstreamer.lowlevel.GValueAPI.GValue;
-
+import static org.freedesktop.gstreamer.lowlevel.GValueAPI.GVALUE_API;
 import static org.freedesktop.gstreamer.lowlevel.GstStructureAPI.GSTSTRUCTURE_API;
 import static org.freedesktop.gstreamer.lowlevel.GstValueAPI.GSTVALUE_API;
 
@@ -209,21 +210,6 @@ public class Structure extends NativeObject {
                 throw new InvalidFieldException("double", fieldName);
             }
         }
-    }
-
-    public <T> List<T> getValueList(String fieldName) {
-        GValue val = GSTSTRUCTURE_API.gst_structure_get_value(this, fieldName);
-        if(!val.g_type.equals(GSTVALUE_API.gst_value_list_get_type())) {
-            return null;
-        }
-
-        int size = GSTVALUE_API.gst_value_list_get_size(val);
-        ArrayList<T> values = new ArrayList<>(size);
-        for (int i = 0; i <size; i++) {
-            //noinspection unchecked
-            values.add((T) GSTVALUE_API.gst_value_list_get_value(val, i).getValue());
-        }
-        return values;
     }
 
     /**
@@ -459,7 +445,28 @@ public class Structure extends NativeObject {
      * @return List of values from the named field
      */
     public <T> List<T> getValues(Class<T> type, String fieldName) {
-        Object val = getValue(fieldName);
+        GValue gValue = GSTSTRUCTURE_API.gst_structure_get_value(this, fieldName);
+        if (gValue == null) {
+            throw new InvalidFieldException(type.getSimpleName(), fieldName);
+        }
+
+        GType gType = gValue.getType();
+        if (gType.equals(GSTVALUE_API.gst_value_list_get_type())) {
+            int size = GSTVALUE_API.gst_value_list_get_size(gValue);
+            ArrayList<T> values = new ArrayList<>(size);
+            for (int i = 0; i <size; i++) {
+                Object o = GSTVALUE_API.gst_value_list_get_value(gValue, i).getValue();
+                if (type.isInstance(o)) {
+                    values.add(type.cast(o));
+                } else {
+                    throw new InvalidFieldException(type.getSimpleName(), fieldName);
+                }
+            }
+
+            return values;
+        }
+
+        Object val = gValue.getValue();
         if (val instanceof GValueAPI.GValueArray) {
             GValueAPI.GValueArray arr = (GValueAPI.GValueArray) val;
             int count = arr.getNValues();

--- a/test/org/freedesktop/gstreamer/StructureTest.java
+++ b/test/org/freedesktop/gstreamer/StructureTest.java
@@ -1,15 +1,16 @@
 package org.freedesktop.gstreamer;
 
-import java.util.Arrays;
-import java.util.List;
-import static org.junit.Assert.*;
-
 import org.freedesktop.gstreamer.lowlevel.GType;
 import org.freedesktop.gstreamer.lowlevel.GValueAPI;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class StructureTest {
 	private Structure structure;
@@ -153,17 +154,23 @@ public class StructureTest {
 		assertEquals(10, structure.getFraction("fraction").getDenominator());
 	}
 
-	@Test
-	public void testValueListInteger() {
-		Caps caps = Caps.fromString("audio/x-raw,rate={44100,48000}");
-		List<Integer> rates = caps.getStructure(0).getValueList("rate");
-		assertEquals(Arrays.asList(44100, 48000), rates);
-	}
+    @Test
+    public void testValueListInteger() {
+        Caps caps = Caps.fromString("audio/x-raw,rate={44100,48000}");
+        List<Integer> rates = caps.getStructure(0).getValues(Integer.class, "rate");
+        assertEquals(Arrays.asList(44100, 48000), rates);
+    }
 
-	@Test
-	public void testValueListStrings() {
-		Caps caps = Caps.fromString("video/x-raw,format={RGB, BGR, RGBx, BGRx}");
-		List<String> formats = caps.getStructure(0).getValueList("format");
-		assertEquals(Arrays.asList("RGB", "BGR", "RGBx","BGRx"), formats);
-	}
+    @Test
+    public void testValueListStrings() {
+        Caps caps = Caps.fromString("video/x-raw,format={RGB, BGR, RGBx, BGRx}");
+        List<String> formats = caps.getStructure(0).getValues(String.class, "format");
+        assertEquals(Arrays.asList("RGB", "BGR", "RGBx","BGRx"), formats);
+    }
+
+    @Test(expected = Structure.InvalidFieldException.class)
+    public void testValueListChecksType() {
+        Caps caps = Caps.fromString("video/x-raw,format={RGB, BGR, RGBx, BGRx}");
+        caps.getStructure(0).getValues(Integer.class, "format");
+    }
 }

--- a/test/org/freedesktop/gstreamer/StructureTest.java
+++ b/test/org/freedesktop/gstreamer/StructureTest.java
@@ -1,5 +1,6 @@
 package org.freedesktop.gstreamer;
 
+import java.util.Arrays;
 import java.util.List;
 import static org.junit.Assert.*;
 
@@ -150,5 +151,19 @@ public class StructureTest {
 		structure.setFraction("fraction", 17, 10);
 		assertEquals(17, structure.getFraction("fraction").getNumerator());
 		assertEquals(10, structure.getFraction("fraction").getDenominator());
+	}
+
+	@Test
+	public void testValueListInteger() {
+		Caps caps = Caps.fromString("audio/x-raw,rate={44100,48000}");
+		List<Integer> rates = caps.getStructure(0).getValueList("rate");
+		assertEquals(Arrays.asList(44100, 48000), rates);
+	}
+
+	@Test
+	public void testValueListStrings() {
+		Caps caps = Caps.fromString("video/x-raw,format={RGB, BGR, RGBx, BGRx}");
+		List<String> formats = caps.getStructure(0).getValueList("format");
+		assertEquals(Arrays.asList("RGB", "BGR", "RGBx","BGRx"), formats);
 	}
 }


### PR DESCRIPTION
Add an Accessor for Structure-Fields of Type `GstValueList`, which is used in the `spectrum`-Message of the `spectrum`-Element and in unfixed-fields of `Caps` .

Fixes #161
