### PR TITLE
Fix leak of gst promise with custom change func

### DIFF
--- a/src/org/freedesktop/gstreamer/Promise.java
+++ b/src/org/freedesktop/gstreamer/Promise.java
@@ -66,7 +66,7 @@ public class Promise extends MiniObject {
             public void callback(Promise promise, Pointer userData) {
                 listener.onChange(promise);
             }
-        }), false, false));
+        }, null, null)));
     }
 
     /**

--- a/src/org/freedesktop/gstreamer/lowlevel/GstPromiseAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GstPromiseAPI.java
@@ -60,8 +60,8 @@ public interface GstPromiseAPI extends com.sun.jna.Library {
   @CallerOwnsReturn Promise gst_promise_new();
   @CallerOwnsReturn Pointer ptr_gst_promise_new();
 
-  @CallerOwnsReturn Promise gst_promise_new_with_change_func(GstCallback callback);
-  @CallerOwnsReturn Pointer ptr_gst_promise_new_with_change_func(GstCallback callback);
+  @CallerOwnsReturn Promise gst_promise_new_with_change_func(GstCallback callback, Pointer userData, Pointer destroyNotify);
+  @CallerOwnsReturn Pointer ptr_gst_promise_new_with_change_func(GstCallback callback, Pointer userData, Pointer destroyNotify);
 
   PromiseResult gst_promise_wait(Promise promise);
 

--- a/test/org/freedesktop/gstreamer/PromiseTest.java
+++ b/test/org/freedesktop/gstreamer/PromiseTest.java
@@ -96,4 +96,28 @@ public class PromiseTest {
         Structure result = promise.getReply();
         assertTrue("result of promise does not match reply", result.isEqual(data));
     }
+
+    @Test
+    public void testDispose() {
+        if (!Gst.testVersion(1, 14)) {
+            return;
+        }
+        Promise promise = new Promise();
+        promise.interrupt();
+        promise.dispose();
+    }
+
+    @Test
+    public void testDisposeWithChangeFunc() {
+        if (!Gst.testVersion(1, 14)) {
+            return;
+        }
+        Promise promise = new Promise(new Promise.PROMISE_CHANGE() {
+            @Override
+            public void onChange(Promise promise) {
+            }
+        });
+        promise.interrupt();
+        promise.dispose();
+    }
 }


### PR DESCRIPTION
Synchronize signatures of `GstPromiseAPI.gst_promise_new_with_change_func`
and `GstPromiseAPI.ptr_gst_promise_new_with_change_func` to C's version,
so that it would not get unknown `user_data` and `notify`, otherwise
we will get coredump in `gst_promise_free`.