### PR TITLE
Invalidate structure after ownership transferred to promise in Promise.reply

### DIFF
--- a/src/org/freedesktop/gstreamer/Promise.java
+++ b/src/org/freedesktop/gstreamer/Promise.java
@@ -19,6 +19,7 @@ package org.freedesktop.gstreamer;
 
 import static org.freedesktop.gstreamer.lowlevel.GstPromiseAPI.GSTPROMISE_API;
 
+import org.freedesktop.gstreamer.glib.NativeObject;
 import org.freedesktop.gstreamer.lowlevel.GstAPI.GstCallback;
 
 import com.sun.jna.Pointer;
@@ -86,7 +87,9 @@ public class Promise extends MiniObject {
      * {@link PromiseResult} state. If the promise has already been interrupted
      * than the replied will not be visible to any waiters
      *
-     * @param structure the {@link Structure} to reply the promise with
+     * @param structure the {@link Structure} to reply the promise with, caller
+     * should not use this structure afterward as it is invalidated through
+     * {@link NativeObject#invalidate()}
      */
     public void reply(final Structure structure) {
         GSTPROMISE_API.gst_promise_reply(this, structure);

--- a/src/org/freedesktop/gstreamer/glib/Natives.java
+++ b/src/org/freedesktop/gstreamer/glib/Natives.java
@@ -188,6 +188,26 @@ public final class Natives {
     }
 
     /**
+     * Return whether underlying native pointer is owned by this object.
+     *
+     * @param obj native object which may hold a reference to native pointer
+     * @return whether underlying native pointer is owned by this object
+     */
+    public static boolean ownsReference(NativeObject obj) {
+        return obj.handle.ownsReference();
+    }
+
+    /**
+     * Returns whether this object is valid or not.
+     *
+     * @param obj native object
+     * @return whether this object is valid or not
+     */
+    public static boolean validReference(NativeObject obj) {
+        return obj.handle.getPointer() != null;
+    }
+
+    /**
      * Increase the reference count of a {@link RefCountedObject}
      *
      * @param <T> type of object

--- a/src/org/freedesktop/gstreamer/lowlevel/GstPromiseAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GstPromiseAPI.java
@@ -28,6 +28,7 @@ import org.freedesktop.gstreamer.lowlevel.GstMiniObjectAPI.MiniObjectStruct;
 import org.freedesktop.gstreamer.lowlevel.annotations.CallerOwnsReturn;
 
 import com.sun.jna.Pointer;
+import org.freedesktop.gstreamer.lowlevel.annotations.Invalidate;
 
 /**
  * GstPromise methods and structures
@@ -65,7 +66,7 @@ public interface GstPromiseAPI extends com.sun.jna.Library {
 
   PromiseResult gst_promise_wait(Promise promise);
 
-  void gst_promise_reply(Promise promise, Structure s);
+  void gst_promise_reply(Promise promise, @Invalidate Structure s);
   void gst_promise_interrupt(Promise promise);
   void gst_promise_expire(Promise promise);
 

--- a/test/org/freedesktop/gstreamer/PromiseTest.java
+++ b/test/org/freedesktop/gstreamer/PromiseTest.java
@@ -19,8 +19,11 @@
 package org.freedesktop.gstreamer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.freedesktop.gstreamer.glib.Natives;
+import org.freedesktop.gstreamer.lowlevel.GPointer;
 import org.freedesktop.gstreamer.lowlevel.GType;
 import org.junit.BeforeClass;
 import org.junit.AfterClass;
@@ -83,17 +86,32 @@ public class PromiseTest {
     }
 
     @Test
+    public void testInvalidateReply() {
+        if (!Gst.testVersion(1, 14)) {
+            return;
+        }
+        Promise promise = new Promise();
+        Structure data = new Structure("data");
+
+        assertTrue(Natives.ownsReference(data));
+        promise.reply(data);
+        assertFalse(Natives.ownsReference(data));
+        assertFalse(Natives.validReference(data));
+    }
+
+    @Test
     public void testReplyData() {
         if (!Gst.testVersion(1, 14)) {
             return;
         }
         Promise promise = new Promise();
         Structure data = new Structure("data", "test", GType.UINT, 1);
+        GPointer pointer = Natives.getPointer(data);
 
         promise.reply(data);
         assertEquals("promise state not in replied", promise.waitResult(), PromiseResult.REPLIED);
 
         Structure result = promise.getReply();
-        assertTrue("result of promise does not match reply", result.isEqual(data));
+        assertEquals("result of promise does not match reply", pointer, Natives.getPointer(result));
     }
 }


### PR DESCRIPTION
    If we don't invalidate after Promise.reply, we may sit in situations:
    
    1. structure got freed while it is owned by promise, we can get hit from
       gst log:
    
       ```
       (PromiseTest:13221): GStreamer-CRITICAL **: 10:28:01.594: gst_structure_free: assertion 'GST_STRUCTURE_REFCOUNT (structure) == NULL' failed
       ```
    2. structure got freed after its owning promise freed, we got
       double-free.
    
    3. structure got used after freed due to interrupted before reply or
       owning promise freed.