### PR TITLE
ISSUE-171 - fix ownership and ref if previously cached unowned

### DIFF
--- a/src/org/freedesktop/gstreamer/glib/NativeObject.java
+++ b/src/org/freedesktop/gstreamer/glib/NativeObject.java
@@ -161,7 +161,13 @@ public abstract class NativeObject implements AutoCloseable {
             if (ownsHandle && !obj.handle.ownsReference()) {
                 obj.handle.ownsReference.set(true);
             } else if (refAdjust < 0) {
-                ((RefCountedObject.Handle) obj.handle).unref(); // Lose the extra ref added by gstreamer
+                try {
+                    // Lose the extra ref added by gstreamer
+                    ((RefCountedObject.Handle) obj.handle).unref();
+                } catch (ClassCastException ex) {
+                    // A none ref-counted object should not get here!
+                    LOG.log(LIFECYCLE, "None ref-counted object returned again from caller owns return.", ex);
+                }
             }
             return cls.cast(obj);
         }

--- a/src/org/freedesktop/gstreamer/glib/NativeObject.java
+++ b/src/org/freedesktop/gstreamer/glib/NativeObject.java
@@ -158,7 +158,9 @@ public abstract class NativeObject implements AutoCloseable {
         NativeObject obj = NativeObject.instanceFor(gptr.getPointer());
 
         if (obj != null && cls.isInstance(obj)) {
-            if (refAdjust < 0) {
+            if (ownsHandle && !obj.handle.ownsReference()) {
+                obj.handle.ownsReference.set(true);
+            } else if (refAdjust < 0) {
                 ((RefCountedObject.Handle) obj.handle).unref(); // Lose the extra ref added by gstreamer
             }
             return cls.cast(obj);


### PR DESCRIPTION
Mark owned and keep ref if an owned reference had been previously cached while unowned.

Seems to be root cause of #171 with Buffers from a pool.