### PR TITLE
Support setting and getting GstObject properties as serialized String

### DIFF
--- a/src/org/freedesktop/gstreamer/glib/GObject.java
+++ b/src/org/freedesktop/gstreamer/glib/GObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Neil C Smith
+ * Copyright (c) 2020 Neil C Smith
  * Copyright (C) 2014 Tom Greenwood <tgreenwood@cafex.com>
  * Copyright (C) 2009 Levente Farkas
  * Copyright (C) 2009 Tamas Korodi <kotyo@zamba.fm>
@@ -350,6 +350,8 @@ public abstract class GObject extends RefCountedObject {
                     uriString = "file://" + path;
                 }
                 GVALUE_API.g_value_set_string(propValue, uriString);
+            } else if (data == null) {
+                GVALUE_API.g_value_set_string(propValue, null);
             } else {
                 GVALUE_API.g_value_set_string(propValue, data.toString());
             }

--- a/src/org/freedesktop/gstreamer/lowlevel/GstValueAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GstValueAPI.java
@@ -1,4 +1,5 @@
 /* 
+ * Copyright (c) 2020 Neil C Smith
  * Copyright (c) 2009 Levente Farkas
  * Copyright (c) 2007, 2008 Wayne Meissner
  * 
@@ -19,10 +20,11 @@
 
 package org.freedesktop.gstreamer.lowlevel;
 
+import com.sun.jna.Pointer;
 import org.freedesktop.gstreamer.lowlevel.GValueAPI.GValue;
 
 /**
- * GstStructure functions
+ * GstValue functions
  */
 public interface GstValueAPI extends com.sun.jna.Library {
 	GstValueAPI GSTVALUE_API = GstNative.load(GstValueAPI.class);
@@ -44,4 +46,8 @@ public interface GstValueAPI extends com.sun.jna.Library {
     int gst_value_get_int_range_max(GValue value);
     int gst_value_list_get_size(GValue value);
     GValue gst_value_list_get_value(GValue value, int index);
+    
+    boolean gst_value_deserialize(GValue value, String src);
+    Pointer gst_value_serialize(GValue value);
+    
 }

--- a/test/org/freedesktop/gstreamer/PropertyTypeTest.java
+++ b/test/org/freedesktop/gstreamer/PropertyTypeTest.java
@@ -1,0 +1,172 @@
+/* 
+ * Copyright (c) 2020 Peter Körner
+ * Copyright (c) 2020 Neil C Smith
+ * 
+ * This file is part of gstreamer-java.
+ *
+ * gstreamer-java is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * gstreamer-java is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with gstreamer-java.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.freedesktop.gstreamer;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class PropertyTypeTest {
+
+    private Element audiotestsrc;
+    private Element filesink;
+
+    @BeforeClass
+    public static void setUpClass() {
+        Gst.init("PropertyTypeTest");
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        Gst.deinit();
+    }
+
+    @Before
+    public void before() {
+        audiotestsrc = ElementFactory.make("audiotestsrc", null);
+        filesink = ElementFactory.make("filesink", null);
+    }
+
+    @Test
+    public void setBool() {
+        audiotestsrc.set("do-timestamp", true);
+        assertEquals(true, audiotestsrc.get("do-timestamp"));
+
+        audiotestsrc.set("do-timestamp", false);
+        assertEquals(false, audiotestsrc.get("do-timestamp"));
+        
+        audiotestsrc.setAsString("do-timestamp", "true");
+        assertEquals("true", audiotestsrc.getAsString("do-timestamp"));
+    }
+
+    @Test
+    public void setDouble() {
+        audiotestsrc.set("freq", 42.23);
+        assertEquals(42.23, audiotestsrc.get("freq"));
+
+        audiotestsrc.set("freq", 5_000_000.);
+        assertEquals(5_000_000., audiotestsrc.get("freq"));
+        
+        audiotestsrc.setAsString("freq", "42.23");
+        assertEquals(42.23, audiotestsrc.get("freq"));
+    }
+
+    @Test
+    public void setInt() {
+        audiotestsrc.set("num-buffers", 0);
+        assertEquals(0, audiotestsrc.get("num-buffers"));
+
+        audiotestsrc.set("num-buffers", 42);
+        assertEquals(42, audiotestsrc.get("num-buffers"));
+
+        audiotestsrc.set("num-buffers", 2147483647);
+        assertEquals(2147483647, audiotestsrc.get("num-buffers"));
+    }
+
+    @Test
+    public void setUInt() {
+        audiotestsrc.set("blocksize", 0);
+        assertEquals(0, audiotestsrc.get("blocksize"));
+
+        audiotestsrc.set("blocksize", 42);
+        assertEquals(42, audiotestsrc.get("blocksize"));
+
+        int maxUnsignedInt = Integer.parseUnsignedInt("4294967295");
+        audiotestsrc.set("blocksize", maxUnsignedInt);
+        assertEquals(maxUnsignedInt, audiotestsrc.get("blocksize"));
+    }
+
+    @Test
+    public void setLong() {
+        audiotestsrc.set("timestamp-offset", 0L);
+        assertEquals(0L, audiotestsrc.get("timestamp-offset"));
+
+        audiotestsrc.set("timestamp-offset", 42L);
+        assertEquals(42L, audiotestsrc.get("timestamp-offset"));
+
+        audiotestsrc.set("timestamp-offset", -42L);
+        assertEquals(-42L, audiotestsrc.get("timestamp-offset"));
+
+        audiotestsrc.set("timestamp-offset", 9223372036854775807L);
+        assertEquals(9223372036854775807L, audiotestsrc.get("timestamp-offset"));
+
+        audiotestsrc.set("timestamp-offset", -9223372036854775808L);
+        assertEquals(-9223372036854775808L, audiotestsrc.get("timestamp-offset"));
+    }
+
+    @Test
+    public void setULong() {
+        filesink.set("max-bitrate", 0L);
+        assertEquals(0L, filesink.get("max-bitrate"));
+
+        long maxUnsignedLong = Long.parseUnsignedLong("18446744073709551615");
+        filesink.set("max-bitrate", maxUnsignedLong);
+        assertEquals(maxUnsignedLong, filesink.get("max-bitrate"));
+        
+        filesink.set("max-bitrate", 42L);
+        assertEquals(42L, filesink.get("max-bitrate"));
+
+        filesink.setAsString("max-bitrate", "18446744073709551615");
+        assertEquals(maxUnsignedLong, filesink.get("max-bitrate"));
+    }
+
+    @Test
+    public void setString() {
+        filesink.set("location", "");
+        assertEquals("", filesink.get("location"));
+
+        filesink.set("location", null);
+        assertNull(filesink.get("location"));
+
+        filesink.set("location", "foobar");
+        assertEquals("foobar", filesink.get("location"));
+    }
+
+    @Test
+    public void setEnum() {
+        audiotestsrc.set("wave", 8);
+        assertEquals(8, audiotestsrc.get("wave"));
+
+        audiotestsrc.setAsString("wave", "Silence");
+        assertEquals(4, audiotestsrc.get("wave"));
+        assertEquals("Silence", audiotestsrc.getAsString("wave"));
+        
+        audiotestsrc.setAsString("wave", "square");
+        assertEquals(1, audiotestsrc.get("wave"));
+        assertEquals("Square", audiotestsrc.getAsString("wave"));
+        
+        audiotestsrc.setAsString("wave", "red-noise");
+        assertEquals(10, audiotestsrc.get("wave"));
+        String redNoise = audiotestsrc.getAsString("wave");
+        assertEquals("Red (brownian) noise", redNoise);
+        audiotestsrc.setAsString("wave", redNoise);
+        assertEquals(10, audiotestsrc.get("wave"));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void setEnumInvalid() {
+        audiotestsrc.set("wave", "FOO");
+    }
+}
+

--- a/test/org/freedesktop/gstreamer/PropertyTypeTest.java
+++ b/test/org/freedesktop/gstreamer/PropertyTypeTest.java
@@ -54,7 +54,7 @@ public class PropertyTypeTest {
 
         audiotestsrc.set("do-timestamp", false);
         assertEquals(false, audiotestsrc.get("do-timestamp"));
-        
+
         audiotestsrc.setAsString("do-timestamp", "true");
         assertEquals("true", audiotestsrc.getAsString("do-timestamp"));
     }
@@ -66,7 +66,7 @@ public class PropertyTypeTest {
 
         audiotestsrc.set("freq", 5_000_000.);
         assertEquals(5_000_000., audiotestsrc.get("freq"));
-        
+
         audiotestsrc.setAsString("freq", "42.23");
         assertEquals(42.23, audiotestsrc.get("freq"));
     }
@@ -122,7 +122,7 @@ public class PropertyTypeTest {
         long maxUnsignedLong = Long.parseUnsignedLong("18446744073709551615");
         filesink.set("max-bitrate", maxUnsignedLong);
         assertEquals(maxUnsignedLong, filesink.get("max-bitrate"));
-        
+
         filesink.set("max-bitrate", 42L);
         assertEquals(42L, filesink.get("max-bitrate"));
 
@@ -150,30 +150,33 @@ public class PropertyTypeTest {
         audiotestsrc.setAsString("wave", "Silence");
         assertEquals(4, audiotestsrc.get("wave"));
         assertEquals("Silence", audiotestsrc.getAsString("wave"));
-        
+
         audiotestsrc.setAsString("wave", "square");
         assertEquals(1, audiotestsrc.get("wave"));
         assertEquals("Square", audiotestsrc.getAsString("wave"));
-        
+
         audiotestsrc.setAsString("wave", "red-noise");
         assertEquals(10, audiotestsrc.get("wave"));
         String redNoise = audiotestsrc.getAsString("wave");
         assertEquals("Red (brownian) noise", redNoise);
         audiotestsrc.setAsString("wave", redNoise);
         assertEquals(10, audiotestsrc.get("wave"));
-        
+
         // invalid value
         audiotestsrc.set("wave", -256);
         assertEquals(0, audiotestsrc.get("wave"));
     }
-    
+
     @Test(expected = IllegalArgumentException.class)
     public void setEnumInvalidString() {
         audiotestsrc.setAsString("wave", "FOO");
     }
-    
+
     @Test
     public void setValueArrayFromString() {
+        if (!Gst.testVersion(1, 14)) {
+            return;
+        }
         Element convert = ElementFactory.make("audioconvert", null);
         convert.setAsString("mix-matrix", "<<(float)0.25, (float)0.45>,<(float)0.65, (float)0.85>>");
         String matrix = convert.getAsString("mix-matrix");
@@ -184,4 +187,3 @@ public class PropertyTypeTest {
         convert.dispose();
     }
 }
-

--- a/test/org/freedesktop/gstreamer/PropertyTypeTest.java
+++ b/test/org/freedesktop/gstreamer/PropertyTypeTest.java
@@ -24,8 +24,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 public class PropertyTypeTest {
 
@@ -162,11 +161,27 @@ public class PropertyTypeTest {
         assertEquals("Red (brownian) noise", redNoise);
         audiotestsrc.setAsString("wave", redNoise);
         assertEquals(10, audiotestsrc.get("wave"));
+        
+        // invalid value
+        audiotestsrc.set("wave", -256);
+        assertEquals(0, audiotestsrc.get("wave"));
     }
     
     @Test(expected = IllegalArgumentException.class)
-    public void setEnumInvalid() {
-        audiotestsrc.set("wave", "FOO");
+    public void setEnumInvalidString() {
+        audiotestsrc.setAsString("wave", "FOO");
+    }
+    
+    @Test
+    public void setValueArrayFromString() {
+        Element convert = ElementFactory.make("audioconvert", null);
+        convert.setAsString("mix-matrix", "<<(float)0.25, (float)0.45>,<(float)0.65, (float)0.85>>");
+        String matrix = convert.getAsString("mix-matrix");
+        assertTrue(matrix.contains("0.2"));
+        assertTrue(matrix.contains("0.4"));
+        assertTrue(matrix.contains("0.6"));
+        assertTrue(matrix.contains("0.8"));
+        convert.dispose();
     }
 }
 


### PR DESCRIPTION
This supports setting and getting GstObject properties in a serialized String format. It makes use of `gst_value_serialize` and `gst_value_deserialize`. This is in GstObject rather than GObject because it relies on GStreamer-specific functionality (with possible thought of splitting off GLib support in future).

This code is intended as an alternative to #187 and includes an adapted version of the test by @MaZderMind in there. It fixes #182 as well as hopefully other uses mentioned in #166 and elsewhere.

Returned String representation of enums is surprising, but also usable in setAsString.