### PR TITLE
do not request event-info for unsupported event-types (ie IDLE)

### DIFF
--- a/src/org/freedesktop/gstreamer/Pad.java
+++ b/src/org/freedesktop/gstreamer/Pad.java
@@ -81,6 +81,7 @@ public class Pad extends GstObject {
 
     public static final String GTYPE_NAME = "GstPad";
     
+    private static final int EVENT_HAS_INFO_MASK = GstPadAPI.GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM | GstPadAPI.GST_PAD_PROBE_TYPE_EVENT_UPSTREAM;
     private final Handle handle;
 
     /**
@@ -395,7 +396,10 @@ public class Pad extends GstObject {
             public PadProbeReturn callback(Pad pad, GstPadProbeInfo probeInfo, Pointer user_data) {
 //        	    System.out.println("CALLBACK " + probeInfo.padProbeType);
                 if ((probeInfo.padProbeType & mask) != 0) {
-                    Event event = GSTPAD_API.gst_pad_probe_info_get_event(probeInfo);
+                    Event event = null;
+                    if ((probeInfo.padProbeType & EVENT_HAS_INFO_MASK) != 0) {
+                        event = GSTPAD_API.gst_pad_probe_info_get_event(probeInfo);
+                    }
                     return listener.eventReceived(pad, event);
                 }
 


### PR DESCRIPTION
Using `Pad.block` often results in the following Assertation being thrown:
```
(gst1-java-core:14957): GStreamer-CRITICAL **: 18:27:10.478: gst_pad_probe_info_get_event: assertion 'info->type & (GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM | GST_PAD_PROBE_TYPE_EVENT_UPSTREAM)' failed
```

On a side-note the "Critical" assertation comes from [this line in gstpad.c](https://github.com/GStreamer/gstreamer/blob/1.16/gst/gstpad.c#L6353-L6354) which is harmless, because it just returns null when the event is neither an Up- nor a Downstream-Event. This occurs here specifically for IDLE-Events. Moving the check into the Caller (which is what this PR does) fixes the Problem.

This fix is part of a set of fixes for #184 and is extracted from #186