### PR TITLE
blocking on both BLOCK and IDLE can result in the probe being called twice

### DIFF
--- a/src/org/freedesktop/gstreamer/Pad.java
+++ b/src/org/freedesktop/gstreamer/Pad.java
@@ -320,7 +320,7 @@ public class Pad extends GstObject {
                 pad.removeCallback(EVENT_PROBE.class, this);
                 return PadProbeReturn.DROP;
             }
-        }, GstPadAPI.GST_PAD_PROBE_TYPE_BLOCKING | GstPadAPI.GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM);
+        }, GstPadAPI.GST_PAD_PROBE_TYPE_IDLE);
     }
 
     /**


### PR DESCRIPTION
Adding a Probe for `GstPadAPI.GST_PAD_PROBE_TYPE_BLOCKING | GstPadAPI.GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM` the Mask did match both, BLOCK and IDLE, which would then possibly call the Runnable twice.

This fix is part of a set of fixes for #184 and is extracted from #186