### PR TITLE
use long-value to avoid type cast

### DIFF
--- a/src/org/freedesktop/gstreamer/glib/GObject.java
+++ b/src/org/freedesktop/gstreamer/glib/GObject.java
@@ -590,7 +590,7 @@ public abstract class GObject extends RefCountedObject {
         protected GCallback(NativeLong id, Callback cb) {
             this.id = id != null ? id : new NativeLong(0);
             this.cb = cb;
-            this.connected = this.id.intValue() != 0;
+            this.connected = this.id.longValue() != 0;
         }
 
         void remove() {


### PR DESCRIPTION
avoids one unnecessary cast from long to int

This fix is part of a set of fixes for #184 and is extracted from #186