### PR TITLE
Add extraction of NativeEnum int value in GObject::set.

### DIFF
--- a/src/org/freedesktop/gstreamer/glib/GObject.java
+++ b/src/org/freedesktop/gstreamer/glib/GObject.java
@@ -303,13 +303,17 @@ public abstract class GObject extends RefCountedObject {
      *
      * @param property The property to set.
      * @param data The value for the property. This must be of the type expected
-     * by gstreamer.
+     * by gstreamer. As a convenience, NativeEnums will be converted to their
+     * int value.
      */
     public void set(String property, Object data) {
         LOG.entering("GObject", "set", new Object[]{property, data});
         GObjectAPI.GParamSpec propertySpec = findProperty(property);
         if (propertySpec == null /*|| data == null*/) {
             throw new IllegalArgumentException("Unknown property: " + property);
+        }
+        if (data instanceof NativeEnum) {
+            data = ((NativeEnum<?>) data).intValue();
         }
         final GType propType = propertySpec.value_type;
 

--- a/test/org/freedesktop/gstreamer/PropertyTypeTest.java
+++ b/test/org/freedesktop/gstreamer/PropertyTypeTest.java
@@ -19,6 +19,7 @@
  */
 package org.freedesktop.gstreamer;
 
+import org.freedesktop.gstreamer.glib.NativeEnum;
 import org.freedesktop.gstreamer.util.TestAssumptions;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -176,6 +177,12 @@ public class PropertyTypeTest {
         // invalid value
         audiotestsrc.set("wave", -256);
         assertEquals(0, audiotestsrc.get("wave"));
+        
+        // native enum
+        audiotestsrc.set("wave", AudioTestSrcWave.SILENCE);
+        assertEquals(AudioTestSrcWave.SILENCE.intValue(), audiotestsrc.get("wave"));
+        assertEquals("Silence", audiotestsrc.getAsString("wave"));
+        
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -194,4 +201,32 @@ public class PropertyTypeTest {
         assertTrue(mixMatrix.contains("0.6"));
         assertTrue(mixMatrix.contains("0.8"));
     }
+    
+     private static enum AudioTestSrcWave implements NativeEnum<AudioTestSrcWave>{
+        SINE(0),
+        SQUARE(1),
+        SAW(2),
+        TRIANGLE(3),
+        SILENCE(4),
+        WHITE_NOISE(5),
+        PINK_NOISE(6),
+        SINE_TABLE(7),
+        TICKS(8),
+        GAUSSIAN_NOISE(9),
+        RED_NOISE(10),
+        BLUE_NOISE(11),
+        VIOLET_NOISE(12);
+
+        private final int value;
+
+        private AudioTestSrcWave(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public int intValue() {
+            return value;
+        }
+    }
+    
 }


### PR DESCRIPTION
Alternative option for extracting NativeEnum values in GObject::set. (see discussion at #214 )