### PR TITLE
Ignore Caps test on Sample temporarily

### DIFF
--- a/test/org/freedesktop/gstreamer/SampleTest.java
+++ b/test/org/freedesktop/gstreamer/SampleTest.java
@@ -1,4 +1,5 @@
 /* 
+ * Copyright (c) 2020 Neil C Smith
  * Copyright (c) 2020 John Cortell
  * 
  * This file is part of gstreamer-java.
@@ -25,6 +26,7 @@ import org.freedesktop.gstreamer.glib.Natives;
 import org.freedesktop.gstreamer.util.TestAssumptions;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class SampleTest {
@@ -43,6 +45,8 @@ public class SampleTest {
     }
 
     @Test
+    @Ignore
+    // @TODO for some reason this test is unreliable on GitHub Actions.
     public void testGetCaps() {
     	SampleTester.test((Sample sample) -> {
     		Caps caps = sample.getCaps();


### PR DESCRIPTION
Ignore Caps test on Sample temporarily - unreliable on GitHub Actions testing. Can't find way to reproduce, or reliable way to trigger - something related to the Structure.