### PR TITLE
Library Name Resolution + GioApi

### DIFF
--- a/src/org/freedesktop/gstreamer/glib/GCancellable.java
+++ b/src/org/freedesktop/gstreamer/glib/GCancellable.java
@@ -26,7 +26,7 @@ public class GCancellable extends GObject{
 	public static final String GTYPE_NAME = "GCancellable";
 
 	public GCancellable() {
-		this(Natives.initializer(GioAPI.g_cancellable_new()));
+		this(Natives.initializer(GioAPI.GIO_API.g_cancellable_new()));
 	}
 	
 	private GCancellable(Initializer init) {

--- a/src/org/freedesktop/gstreamer/glib/GInetAddress.java
+++ b/src/org/freedesktop/gstreamer/glib/GInetAddress.java
@@ -30,7 +30,7 @@ public class GInetAddress extends GObject{
 	}
 
 	public String getAddress() {
-		return GioAPI.g_inet_address_to_string(getRawPointer());
+		return GioAPI.GIO_API.g_inet_address_to_string(getRawPointer());
 	}
 	
 }

--- a/src/org/freedesktop/gstreamer/glib/GInetSocketAddress.java
+++ b/src/org/freedesktop/gstreamer/glib/GInetSocketAddress.java
@@ -44,7 +44,7 @@ public class GInetSocketAddress extends GSocketAddress {
 	}
         
         private static Initializer createRawAddress(String address, int port) {
-            Pointer nativePointer = GioAPI.g_inet_socket_address_new_from_string(address, port);
+            Pointer nativePointer = GioAPI.GIO_API.g_inet_socket_address_new_from_string(address, port);
             if (nativePointer == null) {
                 throw new GLibException("Can not create "+GInetSocketAddress.class.getSimpleName()+" for "+address+":"+port+", please check that the IP address is valid, with format x.x.x.x");
             }

--- a/src/org/freedesktop/gstreamer/glib/GSocket.java
+++ b/src/org/freedesktop/gstreamer/glib/GSocket.java
@@ -40,7 +40,7 @@ public class GSocket extends GObject {
         GInetSocketAddress boundAddress = new GInetSocketAddress(address, port);
         GErrorStruct reference = new GErrorStruct();
         GErrorStruct[] errorArray = (GErrorStruct[]) reference.toArray(1);
-        if (!GioAPI.g_socket_bind(getRawPointer(),
+        if (!GioAPI.GIO_API.g_socket_bind(getRawPointer(),
                 Natives.getRawPointer(boundAddress),
                 true,
                 reference.getPointer())) {
@@ -53,7 +53,7 @@ public class GSocket extends GObject {
         GInetSocketAddress connectedAddress = new GInetSocketAddress(address, port);
         GErrorStruct reference = new GErrorStruct();
         GErrorStruct[] errorArray = (GErrorStruct[]) reference.toArray(1);
-        if (!GioAPI.g_socket_connect(getRawPointer(),
+        if (!GioAPI.GIO_API.g_socket_connect(getRawPointer(),
                 Natives.getRawPointer(connectedAddress),
                 Natives.getRawPointer(new GCancellable()),
                 reference.getPointer())) {
@@ -99,7 +99,7 @@ public class GSocket extends GObject {
     private static Initializer makeRawSocket(GSocketFamily family, GSocketType type, GSocketProtocol protocol) throws GLibException {
         GErrorStruct reference = new GErrorStruct();
         GErrorStruct[] errorArray = (GErrorStruct[]) reference.toArray(1);
-        Pointer socketPointer = GioAPI.g_socket_new(family.toGioValue(), type.toGioValue(), protocol.toGioValue(), reference.getPointer());
+        Pointer socketPointer = GioAPI.GIO_API.g_socket_new(family.toGioValue(), type.toGioValue(), protocol.toGioValue(), reference.getPointer());
         if (socketPointer == null) {
             throw new GLibException(extractAndClearError(errorArray[0]));
         }

--- a/src/org/freedesktop/gstreamer/lowlevel/GioAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GioAPI.java
@@ -19,27 +19,35 @@
 
 package org.freedesktop.gstreamer.lowlevel;
 
-import com.sun.jna.Native;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.sun.jna.Library;
 import com.sun.jna.Pointer;
 
-public class GioAPI {
-	
-    static {
-        Native.register("gio-2.0");
-    }
+public interface GioAPI extends Library {
+
+    Map<String, Object> options = new HashMap<>();
+
+    GioAPI GIO_API = GNative.loadLibrary("gio-2.0", GioAPI.class, options);
 
     // GInetAddress
-    public static native String g_inet_address_to_string(Pointer gInetAddress);
+    public String g_inet_address_to_string(Pointer gInetAddress);
 
     // GstSocketAddress
-    public static native Pointer g_inet_socket_address_new_from_string(String address, int port);
+    public Pointer g_inet_socket_address_new_from_string(String address, int port);
 
     // GstSocket
-    public static native Pointer g_socket_new(int gSocketFamilyEnumValue, int gSocketTypeEnumValue, int gSocketProtcolEnumValue, Pointer gErrorStructArrayPointer);
-    public static native boolean g_socket_bind(Pointer gSocketPointer, Pointer gSocketAddressPointer, boolean allowReuse, Pointer gErrorStructArrayPointer);
-    public static native boolean g_socket_connect(Pointer gSocketPointer, Pointer gSocketAddressPointer, Pointer gCancellablePointer, Pointer gErrorStructArrayPointer);
+    public Pointer g_socket_new(int gSocketFamilyEnumValue, int gSocketTypeEnumValue, int gSocketProtcolEnumValue,
+            Pointer gErrorStructArrayPointer);
+
+    public boolean g_socket_bind(Pointer gSocketPointer, Pointer gSocketAddressPointer, boolean allowReuse,
+            Pointer gErrorStructArrayPointer);
+
+    public boolean g_socket_connect(Pointer gSocketPointer, Pointer gSocketAddressPointer, Pointer gCancellablePointer,
+            Pointer gErrorStructArrayPointer);
 
     // GCancellable
-    public static native Pointer g_cancellable_new();
+    public Pointer g_cancellable_new();
 
 }

--- a/test/org/freedesktop/gstreamer/PluginTest.java
+++ b/test/org/freedesktop/gstreamer/PluginTest.java
@@ -61,7 +61,7 @@ public class PluginTest {
 
     @Test
     public void testGetVersion() {
-        assertTrue(playbackPlugin.getVersion().matches("\\d+\\.\\d+\\.\\d+"));
+        assertTrue(playbackPlugin.getVersion().matches("^(?:\\d+\\.)*\\d+$"));
     }
 
     @Test


### PR DESCRIPTION
https://github.com/gstreamer-java/gst1-java-core/issues/229

* I added the format **%s-0** for windows library resolving.

* I also noticed that GioApi wasn't loaded using GNative library loader. This lead to an error where *gio* is not available when using the msvc build.
Is there a specific reason for gio being loaded as static native library?


* After adding the %s-0, gstreamer lib was found correctly but the glib packaged with gstreamer wasn't found because I had libglib somewhere else in the JNA library search path leading to different libraries being loaded:

1. gstreamer => **gstreamer-1.0-0.dll** (msvc build)
2. glib => **libglib-2.0.dll** (probably build by mingw)
=> Leading to Invalid Memory Access etc...

I added a short circuiting style library name resolving to GNative.loadLibrary that fixes this. But I don't know If you want to have that in your lib. I'm not sure whether this actually leads to more problems. Do you know cases where the library name patterns are different?
The fix resolves the upper case to:
1. gstreamer => **gstreamer-1.0-0.dll** 
2. glib => **glib-2.0-0.dll**

I think correctly resolving the MSVC library is important as on the gstreamer download page it is suggested to windows users to use the msvc build...


Side Note, maybe another issue:
If gstreamer is installed on windows a environment variable is created containing the path of gstreamer.

> GSTREAMER_1_0_ROOT_MSVC_X86_64

Maybe this can be used to automatically add the path to jna library resolving.


