### PR TITLE
Stop GstIterator keeping references alive until GC.

### DIFF
--- a/src/org/freedesktop/gstreamer/Bin.java
+++ b/src/org/freedesktop/gstreamer/Bin.java
@@ -1,5 +1,5 @@
 /* 
- * Copyright (c) 2019 Neil C Smith
+ * Copyright (c) 2021 Neil C Smith
  * Copyright (c) 2016 Christophe Lafolet
  * Copyright (c) 2009 Levente Farkas
  * Copyright (C) 2007 Wayne Meissner
@@ -24,12 +24,12 @@ package org.freedesktop.gstreamer;
 
 import static org.freedesktop.gstreamer.lowlevel.GstBinAPI.GSTBIN_API;
 
-import com.sun.jna.Pointer;
 import java.util.EnumSet;
 import java.util.List;
 import org.freedesktop.gstreamer.glib.NativeFlags;
 import org.freedesktop.gstreamer.glib.Natives;
 import org.freedesktop.gstreamer.lowlevel.GstAPI.GstCallback;
+import org.freedesktop.gstreamer.lowlevel.GstIteratorPtr;
 import org.freedesktop.gstreamer.lowlevel.GstObjectPtr;
 
 /**
@@ -145,8 +145,8 @@ public class Bin extends Element {
         GSTBIN_API.gst_bin_remove_many(this, elements);
     }
 
-    private List<Element> elementList(Pointer iter) {
-        return new GstIterator<Element>(iter, Element.class).asList();
+    private List<Element> elementList(GstIteratorPtr iter) {
+        return GstIterator.asList(iter, Element.class);
     }
 
     /**

--- a/src/org/freedesktop/gstreamer/Element.java
+++ b/src/org/freedesktop/gstreamer/Element.java
@@ -31,10 +31,11 @@ import org.freedesktop.gstreamer.glib.Natives;
 
 import org.freedesktop.gstreamer.lowlevel.GstAPI.GstCallback;
 import org.freedesktop.gstreamer.lowlevel.GstContextPtr;
+import org.freedesktop.gstreamer.lowlevel.GstIteratorPtr;
+import org.freedesktop.gstreamer.lowlevel.GstObjectPtr;
 
 import static org.freedesktop.gstreamer.lowlevel.GstElementAPI.GSTELEMENT_API;
 import static org.freedesktop.gstreamer.lowlevel.GObjectAPI.GOBJECT_API;
-import org.freedesktop.gstreamer.lowlevel.GstObjectPtr;
 
 /**
  * Abstract base class for all pipeline elements.
@@ -82,7 +83,7 @@ public class Element extends GstObject {
     protected Element(Initializer init) {
         super(init);
     }
-    
+
     Element(Handle handle, boolean needRef) {
         super(handle, needRef);
     }
@@ -346,7 +347,7 @@ public class Element extends GstObject {
      * @return the List of {@link Pad}s.
      */
     public List<Pad> getPads() {
-        return new GstIterator<Pad>(GSTELEMENT_API.gst_element_iterate_pads(this), Pad.class).asList();
+        return padList(GSTELEMENT_API.gst_element_iterate_pads(this));
     }
 
     /**
@@ -355,7 +356,7 @@ public class Element extends GstObject {
      * @return the List of {@link Pad}s.
      */
     public List<Pad> getSrcPads() {
-        return new GstIterator<Pad>(GSTELEMENT_API.gst_element_iterate_src_pads(this), Pad.class).asList();
+        return padList(GSTELEMENT_API.gst_element_iterate_src_pads(this));
     }
 
     /**
@@ -364,7 +365,11 @@ public class Element extends GstObject {
      * @return the List of {@link Pad}s.
      */
     public List<Pad> getSinkPads() {
-        return new GstIterator<Pad>(GSTELEMENT_API.gst_element_iterate_sink_pads(this), Pad.class).asList();
+        return padList(GSTELEMENT_API.gst_element_iterate_sink_pads(this));
+    }
+    
+    private List<Pad> padList(GstIteratorPtr iter) {
+        return GstIterator.asList(iter, Pad.class);
     }
 
     /**
@@ -770,7 +775,7 @@ public class Element extends GstObject {
 
     /**
      * Gets the context with the context_type set on the element or NULL.
-     * 
+     *
      * @param context_type
      * @return a context or NULL
      */
@@ -780,11 +785,11 @@ public class Element extends GstObject {
     }
 
     static class Handle extends GstObject.Handle {
-        
+
         public Handle(GstObjectPtr ptr, boolean ownsHandle) {
             super(ptr, ownsHandle);
         }
-        
+
     }
 
 }

--- a/src/org/freedesktop/gstreamer/lowlevel/GstBinAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GstBinAPI.java
@@ -1,4 +1,5 @@
 /* 
+ * Copyright (c) 2021 Neil C Smith
  * Copyright (c) 2009 Levente Farkas
  * Copyright (c) 2007, 2008 Wayne Meissner
  * 
@@ -43,12 +44,12 @@ public interface GstBinAPI extends com.sun.jna.Library {
     @CallerOwnsReturn Element gst_bin_get_by_name(Bin bin, String name);
     @CallerOwnsReturn Element gst_bin_get_by_name_recurse_up(Bin bin, String name);
     @CallerOwnsReturn Element gst_bin_get_by_interface(Bin bin, GType iface);
-    Pointer gst_bin_iterate_elements(Bin bin);
-    Pointer gst_bin_iterate_sorted(Bin bin);
-    Pointer gst_bin_iterate_recurse(Bin bin);
-    Pointer gst_bin_iterate_sinks(Bin bin);
-    Pointer gst_bin_iterate_sources(Bin bin);
-    Pointer gst_bin_iterate_all_by_interface(Bin bin, GType iface);
+    GstIteratorPtr gst_bin_iterate_elements(Bin bin);
+    GstIteratorPtr gst_bin_iterate_sorted(Bin bin);
+    GstIteratorPtr gst_bin_iterate_recurse(Bin bin);
+    GstIteratorPtr gst_bin_iterate_sinks(Bin bin);
+    GstIteratorPtr gst_bin_iterate_sources(Bin bin);
+    GstIteratorPtr gst_bin_iterate_all_by_interface(Bin bin, GType iface);
 
     //Debugging
     void gst_debug_bin_to_dot_file (Bin bin, int details, String file_name);

--- a/src/org/freedesktop/gstreamer/lowlevel/GstElementAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GstElementAPI.java
@@ -1,4 +1,5 @@
 /* 
+ * Copyright (c) 2021 Neil C Smith
  * Copyright (c) 2009 Levente Farkas
  * Copyright (c) 2007, 2008 Wayne Meissner
  * 
@@ -83,9 +84,9 @@ public interface GstElementAPI extends com.sun.jna.Library {
     boolean gst_element_link_pads_filtered(Element src, String srcpadname, Element dest, String destpadname,
             Caps filter);
     
-    Pointer gst_element_iterate_pads(Element element);
-    Pointer gst_element_iterate_src_pads(Element element);
-    Pointer gst_element_iterate_sink_pads(Element element);
+    GstIteratorPtr gst_element_iterate_pads(Element element);
+    GstIteratorPtr gst_element_iterate_src_pads(Element element);
+    GstIteratorPtr gst_element_iterate_sink_pads(Element element);
     /* factory management */
     ElementFactory gst_element_get_factory(Element element);
     @CallerOwnsReturn Bus gst_element_get_bus(Element element);

--- a/src/org/freedesktop/gstreamer/lowlevel/GstIteratorAPI.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GstIteratorAPI.java
@@ -1,7 +1,5 @@
 /* 
- * Copyright (c) 2016 Neil C Smith
- * Copyright (c) 2009 Levente Farkas
- * Copyright (c) 2007, 2008 Wayne Meissner
+ * Copyright (c) 2021 Neil C Smith
  * 
  * This file is part of gstreamer-java.
  *
@@ -20,15 +18,14 @@
 
 package org.freedesktop.gstreamer.lowlevel;
 
-import com.sun.jna.Pointer;
-
 /**
  * GstIterator functions
  */
 public interface GstIteratorAPI extends com.sun.jna.Library {
+    
     GstIteratorAPI GSTITERATOR_API = GstNative.load(GstIteratorAPI.class);
 
-    void gst_iterator_free(Pointer iter);
-    int gst_iterator_next(Pointer iter, GValueAPI.GValue next);
-    void gst_iterator_resync(Pointer iter);
+    void gst_iterator_free(GstIteratorPtr iter);
+    int gst_iterator_next(GstIteratorPtr iter, GValueAPI.GValue next);
+    void gst_iterator_resync(GstIteratorPtr iter);
 }

--- a/src/org/freedesktop/gstreamer/lowlevel/GstIteratorPtr.java
+++ b/src/org/freedesktop/gstreamer/lowlevel/GstIteratorPtr.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021 Neil C Smith
+ * 
+ * This file is part of gstreamer-java.
+ *
+ * This code is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License version 3 only, as published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3 along with
+ * this work. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.freedesktop.gstreamer.lowlevel;
+
+import com.sun.jna.Pointer;
+
+/**
+ * GstIterator pointer.
+ */
+public class GstIteratorPtr extends GPointer {
+
+    public GstIteratorPtr() {
+    }
+
+    public GstIteratorPtr(Pointer ptr) {
+        super(ptr);
+    }
+
+}


### PR DESCRIPTION
Change GstIterator support to stop keeping references alive until garbage collection runs. This includes keeping a reference to the parent object (eg. Element / Bin) that has the iterated elements or pads.

Migrate lowlevel GstIterator API to typed pointer.
Move GstIterator from NativeObject subclass to utility method holder.
Directly fill list and free gstiterator eagerly.
Update Element (pads) and Bin (elements) methods.

The returned lists are no longer wrapped via `Collections.unmodifiableList(..)` and the underlying type is changed from `LinkedList` to `ArrayList`.