### PR TITLE
Fix read after free bug

### DIFF
--- a/src/org/freedesktop/gstreamer/Gst.java
+++ b/src/org/freedesktop/gstreamer/Gst.java
@@ -358,7 +358,8 @@ public final class Gst {
         GErrorStruct struct = new GErrorStruct(errorPtr);
         struct.read();
         GError err = new GError(struct.getCode(), struct.getMessage());
-        GLIB_API.g_error_free(struct);
+        // freeing via raw pointer to prevent JNA from reading contents of the freed structure
+        GLIB_API.g_error_free(errorPtr);
         return err;
     }
 


### PR DESCRIPTION
## Problem
JNA reads structure content for structures passed by reference. In this particular case since g_error_free function releases memory used by structure passed to it, this results in "read after free" bug.  This leads to segmentation fault.

Here is example stack trace:
```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007ff81b607f12, pid=70813, tid=38659
...
C  [libsystem_platform.dylib+0xf12]  _platform_strlen+0x12
C  [jna8103589467894918189.tmp+0x5183]  Java_com_sun_jna_Native_getStringBytes+0x23
j  com.sun.jna.Native.getStringBytes(Lcom/sun/jna/Pointer;JJ)[B+0
j  com.sun.jna.Native.getString(Lcom/sun/jna/Pointer;JLjava/lang/String;)Ljava/lang/String;+6
j  com.sun.jna.Pointer.getString(JLjava/lang/String;)Ljava/lang/String;+3
j  com.sun.jna.Pointer.getString(J)Ljava/lang/String;+5
j  org.freedesktop.gstreamer.lowlevel.GTypeMapper$4.fromNative(Ljava/lang/Object;Lcom/sun/jna/FromNativeContext;)Ljava/lang/Object;+76
j  com.sun.jna.Structure.readField(Lcom/sun/jna/Structure$StructField;)Ljava/lang/Object;+169
j  com.sun.jna.Structure.read()V+90
j  com.sun.jna.Structure.autoRead()V+8
j  com.sun.jna.Function.invoke(Ljava/lang/reflect/Method;[Ljava/lang/Class;Ljava/lang/Class;[Ljava/lang/Object;Ljava/util/Map;)Ljava/lang/Object;+380
j  com.sun.jna.Library$Handler.invoke(Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;+390
j  jdk.proxy2.$Proxy5.g_error_free(Lorg/freedesktop/gstreamer/lowlevel/GstAPI$GErrorStruct;)V+16 jdk.proxy2
```
## Solution
Use raw pointer variant of g_error_free function to prevent reading of a released structure.